### PR TITLE
Decorator preserve signature

### DIFF
--- a/dogpile/cache/region.py
+++ b/dogpile/cache/region.py
@@ -1249,7 +1249,7 @@ class CacheRegion(object):
         if function_key_generator is None:
             function_key_generator = self.function_key_generator
 
-        def get_or_create_wrapper(key_generator, user_func, *arg, **kw):
+        def get_or_create_for_user_func(key_generator, user_func, *arg, **kw):
             key = key_generator(*arg, **kw)
 
             @wraps(user_func)
@@ -1269,8 +1269,10 @@ class CacheRegion(object):
                     namespace, user_func,
                     to_str=to_str)
 
-            # Like invalidate, but regenerates the value instead
             def refresh(*arg, **kw):
+                """
+                Like invalidate, but regenerates the value instead
+                """
                 key = key_generator(*arg, **kw)
                 value = user_func(*arg, **kw)
                 self.set(key, value)
@@ -1294,7 +1296,9 @@ class CacheRegion(object):
             user_func.refresh = refresh
             user_func.original = user_func
 
-            return decorate(user_func, partial(get_or_create_wrapper, key_generator))
+            # Use `decorate` to preserve the signature of :param:`user_func`.
+
+            return decorate(user_func, partial(get_or_create_for_user_func, key_generator))
 
         return cache_decorator
 
@@ -1424,7 +1428,7 @@ class CacheRegion(object):
         if function_multi_key_generator is None:
             function_multi_key_generator = self.function_multi_key_generator
 
-        def get_or_create_wrapper(key_generator, user_func, *arg, **kw):
+        def get_or_create_for_user_func(key_generator, user_func, *arg, **kw):
             cache_keys = arg
             keys = key_generator(*arg, **kw)
             key_lookup = dict(zip(keys, cache_keys))
@@ -1504,7 +1508,9 @@ class CacheRegion(object):
             user_func.refresh = refresh
             user_func.get = get
 
-            return decorate(user_func, partial(get_or_create_wrapper, key_generator))
+            # Use `decorate` to preserve the signature of :param:`user_func`.
+
+            return decorate(user_func, partial(get_or_create_for_user_func, key_generator))
 
         return cache_decorator
 

--- a/dogpile/cache/region.py
+++ b/dogpile/cache/region.py
@@ -10,8 +10,9 @@ from ..util import compat
 import time
 import datetime
 from numbers import Number
-from functools import wraps
+from functools import wraps, partial
 import threading
+from decorator import decorate
 
 _backend_loader = PluginLoader("dogpile.cache")
 register_backend = _backend_loader.register
@@ -1248,26 +1249,32 @@ class CacheRegion(object):
         if function_key_generator is None:
             function_key_generator = self.function_key_generator
 
-        def decorator(fn):
+        def get_or_create_wrapper(key_generator, user_func, *arg, **kw):
+            key = key_generator(*arg, **kw)
+
+            @wraps(user_func)
+            def creator():
+                return user_func(*arg, **kw)
+            timeout = expiration_time() if expiration_time_is_callable \
+                else expiration_time
+            return self.get_or_create(key, creator, timeout,
+                                      should_cache_fn)
+
+        def cache_decorator(user_func):
             if to_str is compat.string_type:
                 # backwards compatible
-                key_generator = function_key_generator(namespace, fn)
+                key_generator = function_key_generator(namespace, user_func)
             else:
                 key_generator = function_key_generator(
-                    namespace, fn,
+                    namespace, user_func,
                     to_str=to_str)
 
-            @wraps(fn)
-            def decorate(*arg, **kw):
+            # Like invalidate, but regenerates the value instead
+            def refresh(*arg, **kw):
                 key = key_generator(*arg, **kw)
-
-                @wraps(fn)
-                def creator():
-                    return fn(*arg, **kw)
-                timeout = expiration_time() if expiration_time_is_callable \
-                    else expiration_time
-                return self.get_or_create(key, creator, timeout,
-                                          should_cache_fn)
+                value = user_func(*arg, **kw)
+                self.set(key, value)
+                return value
 
             def invalidate(*arg, **kw):
                 key = key_generator(*arg, **kw)
@@ -1281,20 +1288,15 @@ class CacheRegion(object):
                 key = key_generator(*arg, **kw)
                 return self.get(key)
 
-            def refresh(*arg, **kw):
-                key = key_generator(*arg, **kw)
-                value = fn(*arg, **kw)
-                self.set(key, value)
-                return value
+            user_func.set = set_
+            user_func.invalidate = invalidate
+            user_func.get = get
+            user_func.refresh = refresh
+            user_func.original = user_func
 
-            decorate.set = set_
-            decorate.invalidate = invalidate
-            decorate.refresh = refresh
-            decorate.get = get
-            decorate.original = fn
+            return decorate(user_func, partial(get_or_create_wrapper, key_generator))
 
-            return decorate
-        return decorator
+        return cache_decorator
 
     def cache_multi_on_arguments(
             self, namespace=None, expiration_time=None,

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     dogpile.cache = dogpile.cache.plugins.mako_cache:MakoPlugin
     """,
     zip_safe=False,
+    install_requires=['decorator<5'],
     tests_require=['pytest', 'pytest-cov', 'mock', 'Mako'],
     cmdclass={'test': PyTest},
 )

--- a/tests/cache/test_decorator.py
+++ b/tests/cache/test_decorator.py
@@ -8,7 +8,7 @@ from dogpile.cache import util
 from dogpile.util import compat
 import itertools
 from dogpile.cache.api import NO_VALUE
-
+import inspect
 
 class DecoratorTest(_GenericBackendFixture, TestCase):
     backend = "dogpile.cache.memory"
@@ -593,7 +593,6 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         def func(a, b, c=True, *args, **kwargs):
             return None
 
-        import inspect
         signature = inspect.getargspec(func)
         cached_func = reg.cache_on_arguments()(func)
         cached_signature = inspect.getargspec(cached_func)
@@ -606,7 +605,6 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         def func(a, b, c=True, *args, **kwargs):
             return None, None
 
-        import inspect
         signature = inspect.getargspec(func)
         cached_func = reg.cache_multi_on_arguments()(func)
         cached_signature = inspect.getargspec(cached_func)

--- a/tests/cache/test_decorator.py
+++ b/tests/cache/test_decorator.py
@@ -586,3 +586,29 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
 
         generate.set({7: 18, 10: 15})
         eq_(generate(2, 7, 10), ['2 5', 18, 15])
+
+    def test_cache_preserve_sig(self):
+        reg = self._region()
+
+        def func(a, b, c=True, *args, **kwargs):
+            return None
+
+        import inspect
+        signature = inspect.getargspec(func)
+        cached_func = reg.cache_on_arguments()(func)
+        cached_signature = inspect.getargspec(cached_func)
+
+        self.assertEqual(signature, cached_signature)
+
+    def test_cache_multi_preserve_sig(self):
+        reg = self._region()
+
+        def func(a, b, c=True, *args, **kwargs):
+            return None, None
+
+        import inspect
+        signature = inspect.getargspec(func)
+        cached_func = reg.cache_multi_on_arguments()(func)
+        cached_signature = inspect.getargspec(cached_func)
+
+        self.assertEqual(signature, cached_signature)

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ deps=
 	pytest
 	mock
 	Mako
-	decorator
 	{memcached}: pylibmc
 
 	# the py3k python-memcached fails for multiple

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps=
 	pytest
 	mock
 	Mako
+	decorator
 	{memcached}: pylibmc
 
 	# the py3k python-memcached fails for multiple


### PR DESCRIPTION
Hi,
We've been using your caching framework for some time now and we've discovered an issue where the decorators `@cache_on_arguments` (and `@cache_multi_on_arguments`) don't preserve the signatures of the decorated functions.  An example:
```
In [1]: from dogpile.cache import make_region

In [2]: region = make_region().configure(
   ...:     'dogpile.cache.memory'
   ...: )

In [3]: import inspect

In [4]: def func(a, b, c=True, *args, **kwargs):
   ...:     return None

In [5]: inspect.getargspec(func)
Out[5]: ArgSpec(args=['a', 'b', 'c'], varargs='args', keywords='kwargs', defaults=(True,))

In [6]: cached_func = region.cache_on_arguments()(func)

In [7]: inspect.getargspec(cached_func)
Out[7]: ArgSpec(args=[], varargs='arg', keywords='kw', defaults=None)
```

To remedy this, I'm submitting a PR that uses the [decorator](https://github.com/micheles/decorator) module to preserve the signature of functions decorated by `cache_on_arguments`.

I've also added tests to check this behavior.

I wasn't sure where to put a new dependency, so I put it in setup.py under `install_requires`.  Let me know if there's a better place for it

Thanks!
