### PR TITLE
FilesBackend and RangedFileLock

### DIFF
--- a/dogpile/cache/backends/__init__.py
+++ b/dogpile/cache/backends/__init__.py
@@ -5,6 +5,8 @@ register_backend(
 register_backend(
     "dogpile.cache.dbm", "dogpile.cache.backends.file", "DBMBackend")
 register_backend(
+    "dogpile.cache.files", "dogpile.cache.backends.file", "FilesBackend")
+register_backend(
     "dogpile.cache.pylibmc", "dogpile.cache.backends.memcached",
     "PylibmcBackend")
 register_backend(

--- a/dogpile/cache/backends/file.py
+++ b/dogpile/cache/backends/file.py
@@ -7,13 +7,30 @@ Provides backends that deal with local filesystem access.
 """
 
 from __future__ import with_statement
-from ..api import CacheBackend, NO_VALUE
-from contextlib import contextmanager
-from ...util import compat
-from ... import util
-import os
 
-__all__ = 'DBMBackend', 'FileLock', 'AbstractFileLock'
+import codecs
+import datetime
+import errno
+import hashlib
+import io
+import logging
+import os
+import pickle
+import sys
+import tempfile
+from contextlib import contextmanager
+from shutil import copyfileobj
+
+import pytz
+import six
+
+from ..api import CacheBackend, NO_VALUE, CachedValue
+from ... import util
+from ...util import compat
+
+__all__ = 'DBMBackend', 'FilesBackend', 'FileLock', 'AbstractFileLock', 'RangedFileLock'
+
+logger = logging.getLogger(__name__)
 
 
 class DBMBackend(CacheBackend):
@@ -134,6 +151,7 @@ class DBMBackend(CacheBackend):
 
 
     """
+
     def __init__(self, arguments):
         self.filename = os.path.abspath(
             os.path.normpath(arguments['filename'])
@@ -445,3 +463,349 @@ class FileLock(AbstractFileLock):
             self._module.flock(fileno, self._module.LOCK_UN)
             os.close(fileno)
             del self._filedescriptor.fileno
+
+
+def _remove(file_path):
+    try:
+        os.remove(file_path)
+    except (IOError, OSError):
+        logger.exception('Cannot remove file {}'.format(file_path))
+
+
+def _ensure_dir(path):
+    try:
+        os.makedirs(path)
+    except OSError as error:
+        if error.errno != errno.EEXIST:
+            raise
+    except (OSError, IOError):
+        logger.exception('Cannot create directory {}'.format(path))
+
+
+def _stat(file_path):
+    try:
+        return os.stat(file_path)
+    except (IOError, OSError):
+        logger.exception('Cannot stat file {}'.format(file_path))
+        return None
+
+
+def _get_size(stat):
+    if stat is None:
+        return 0
+    return stat.st_size
+
+
+def _get_last_modified(stat):
+    if stat is None:
+        return datetime.datetime.fromtimestamp(0, tz=pytz.utc)
+    return datetime.datetime.fromtimestamp(stat.st_mtime, pytz.utc)
+
+
+def without_suffixes(string, suffixes):
+    for suffix in suffixes:
+        if string.endswith(suffix):
+            return string[:-len(suffix)]
+    return string
+
+
+def sha256_mangler(key):
+    if isinstance(key, six.text_type):
+        key = key.encode('utf-8')
+    return hashlib.sha256(key).hexdigest()
+
+
+class FilesBackend(CacheBackend):
+    """A file-backend using files to store keys.
+
+    Basic usage::
+
+        from dogpile.cache import make_region
+
+        region = make_region().configure(
+            'paylogic.files_backend',
+            expiration_time = datetime.timedelta(seconds=30),
+            arguments = {
+                "base_dir": "/path/to/cachedir",
+                "file_movable": True,
+                "cache_size": 1024*1024*1024,  # 1 Gb
+                "expiration_time: datetime.timedelta(seconds=30),
+            }
+        )
+
+        @region.cache_on_arguments()
+        def big_file_operation(args):
+            f = tempfile.NamedTemporaryFile(delete=False)
+            # fill the file
+            f.flush()
+            f.seek(0)
+            return f
+
+
+    Parameters to the ``arguments`` dictionary are
+    below.
+
+    :param base_dir: path of the directory where to store the files.
+    :param expiration_time: expiration time of the keys
+    :param cache_size: the maximum size of the directory. Once exceeded, keys will be removed in a
+                       LRU fashion.
+    :param file_movable: whether the file provided to .set() can be moved. If that's the case,
+                         the backend will avoid copying the contents.
+    """
+
+    @staticmethod
+    def key_mangler(key):
+        return hashlib.sha256(key.encode('utf-8')).hexdigest()
+
+    def __init__(self, arguments):
+        # TODO: Add self.lock_expiration
+        self.base_dir = os.path.abspath(
+            os.path.normpath(arguments['base_dir'])
+        )
+        _ensure_dir(self.base_dir)
+
+        self.values_dir = os.path.join(self.base_dir, 'values')
+        _ensure_dir(self.values_dir)
+
+        self.dogpile_lock_path = os.path.join(self.base_dir, 'dogpile.lock')
+        self.rw_lock_path = os.path.join(self.base_dir, 'rw.lock')
+
+        self.expiration_time = arguments.get('expiration_time')
+        self.cache_size = arguments.get('cache_size', 1024 * 1024 * 1024)  # 1 Gb
+        self.file_movable = arguments.get('file_movable', False)
+        self.distributed_lock = arguments.get('distributed_lock', True)
+
+
+    def _get_rw_lock(self, key):
+        return RangedFileLock(self.rw_lock_path, key)
+
+    def _get_dogpile_lock(self, key):
+        return RangedFileLock(self.dogpile_lock_path, key)
+
+    def get_mutex(self, key):
+        if self.distributed_lock:
+            return self._get_dogpile_lock(key)
+
+            # # We need to hash the key, as it may not have used our key mangler
+            # hash = hashlib.sha256(key.encode('utf-8')).hexdigest()
+            # partition_key = hash[:self.dogpile_lock_partition_size * 2]
+            # return FileLock(os.path.join(self.base_dir, 'dogpile_locks', partition_key))
+        else:
+            return None
+
+    def _file_path_payload(self, key):
+        return os.path.join(self.values_dir, key + '.payload')
+
+    def _file_path_metadata(self, key):
+        return os.path.join(self.values_dir, key + '.metadata')
+
+    def _file_path_type(self, key):
+        return os.path.join(self.values_dir, key + '.type')
+
+    def get(self, key):
+        now = datetime.datetime.now(tz=pytz.utc)
+        file_path_payload = self._file_path_payload(key)
+        file_path_metadata = self._file_path_metadata(key)
+        file_path_type = self._file_path_type(key)
+        with self._get_rw_lock(key).read():
+            if not os.path.exists(file_path_payload) or not os.path.exists(file_path_metadata)\
+                    or not os.path.exists(file_path_type):
+                return NO_VALUE
+            if self.expiration_time is not None:
+                if _get_last_modified(_stat(file_path_payload)) < now - self.expiration_time:
+                    return NO_VALUE
+
+            with open(file_path_metadata, 'rb') as i:
+                metadata = pickle.load(i)
+            with open(file_path_type, 'rb') as i:
+                type = pickle.load(i)
+            if type == 'file':
+                return CachedValue(
+                    open(file_path_payload, 'rb'),
+                    metadata,
+                )
+            elif metadata is not None:
+                with open(file_path_payload, 'rb') as i:
+                    return CachedValue(
+                        pickle.load(i),
+                        metadata,
+                    )
+            else:
+                with open(file_path_payload, 'rb') as i:
+                    return pickle.load(i)
+
+    def get_multi(self, keys):
+        return [self.get(key) for key in keys]
+
+    def set(self, key, value):
+        self._prune()
+        if isinstance(value, CachedValue):
+            payload, metadata = value.payload, value.metadata
+        else:
+            payload, metadata = value, None
+        with tempfile.NamedTemporaryFile(delete=False) as metadata_file:
+            pickle.dump(metadata, metadata_file, pickle.HIGHEST_PROTOCOL)
+
+        if not isinstance(payload, io.IOBase):
+            type = 'value'
+            with tempfile.NamedTemporaryFile(delete=False) as payload_file:
+                pickle.dump(payload, payload_file, pickle.HIGHEST_PROTOCOL)
+            payload_file_path = payload_file.name
+        else:
+            type = 'file'
+            if self.file_movable and hasattr(payload, 'name'):
+                payload_file_path = payload.name
+            else:
+                payload.seek(0)
+
+                with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
+                    copyfileobj(payload, tmpfile, length=1024 * 1024)
+                payload_file_path = tmpfile.name
+
+        with tempfile.NamedTemporaryFile(delete=False) as type_file:
+            pickle.dump(type, type_file, pickle.HIGHEST_PROTOCOL)
+
+        with self._get_rw_lock(key).write():
+            os.rename(metadata_file.name, self._file_path_metadata(key))
+            os.rename(type_file.name, self._file_path_type(key))
+            os.rename(payload_file_path, self._file_path_payload(key))
+
+    def set_multi(self, mapping):
+        for key, value in mapping.items():
+            self.set(key, value)
+
+    def delete(self, key):
+        with self._get_rw_lock(key).write():
+            self._delete_key_files(key)
+
+    def delete_multi(self, keys):
+        for key in keys:
+            self.delete(key)
+
+    def _delete_key_files(self, key):
+        _remove(self._file_path_payload(key))
+        _remove(self._file_path_metadata(key))
+
+    def _list_keys_with_desc(self):
+        suffixes = ['.payload', '.metadata', '.type']
+        files = [
+            file_name for file_name in os.listdir(self.values_dir)
+            if any(file_name.endswith(s) for s in suffixes)
+        ]
+        files_with_stats = {
+            f: _stat(os.path.join(self.values_dir, f)) for f in files
+        }
+
+        keys = set(
+            without_suffixes(f, suffixes)
+            for f in files
+        )
+
+        return {
+            key: {
+                'last_modified': _get_last_modified(files_with_stats.get(key + '.payload', None)),
+                'size': (
+                        _get_size(files_with_stats.get(key + '.payload'))
+                        + _get_size(files_with_stats.get(key + '.metadata'))
+                        + _get_size(files_with_stats.get(key + '.type'))
+                ),
+            }
+            for key in keys
+        }
+
+    def attempt_delete_key(self, key):
+        rw_lock = self._get_rw_lock(key)
+        if rw_lock.acquire_write_lock(wait=False):
+            try:
+                self._delete_key_files(key)
+            finally:
+                rw_lock.release_write_lock()
+
+    def _prune(self):
+        now = datetime.datetime.now(tz=pytz.utc)
+        keys_with_desc = self._list_keys_with_desc()
+        keys = set(keys_with_desc)
+        remaining_keys = set(keys_with_desc)
+
+        if self.expiration_time is not None:
+            for key in keys:
+                if keys_with_desc[key]['last_modified'] >= now - self.expiration_time:
+                    continue
+                self.attempt_delete_key(key)
+                remaining_keys.discard(key)
+
+        keys_by_newest = sorted(
+            remaining_keys,
+            key=lambda key: keys_with_desc[key]['last_modified'],
+            reverse=True,
+        )
+        while sum((keys_with_desc[key]['size'] for key in remaining_keys), 0) > self.cache_size:
+            if not keys_by_newest:
+                break
+            key = keys_by_newest.pop()
+            self.attempt_delete_key(key)
+
+
+def _key_to_offset(key, max=sys.maxint):
+    # Map any string to randomly distributed integers between 0 and max
+    hash = hashlib.sha1(key.encode('utf-8')).digest()
+    return int(codecs.encode(hash, 'hex'), 16) % max
+
+
+class RangedFileLock(AbstractFileLock):
+    def __init__(self, path, key=None):
+        if key is None:
+            self.key_offset = None
+        else:
+            self.key_offset = _key_to_offset(key)
+        self._filedescriptor = None
+        self.path = path
+
+    @util.memoized_property
+    def _module(self):
+        import fcntl
+        return fcntl
+
+    def acquire_read_lock(self, wait):
+        return self._acquire(wait, os.O_RDONLY, self._module.LOCK_SH)
+
+    def acquire_write_lock(self, wait):
+        return self._acquire(wait, os.O_WRONLY, self._module.LOCK_EX)
+
+    def release_read_lock(self):
+        self._release()
+
+    def release_write_lock(self):
+        self._release()
+
+    def _acquire(self, wait, wrflag, lockflag):
+        wrflag |= os.O_CREAT
+        fileno = os.open(self.path, wrflag)
+        try:
+            if not wait:
+                lockflag |= self._module.LOCK_NB
+            if self.key_offset is not None:
+                self._module.lockf(fileno, lockflag, 1, self.key_offset)
+            else:
+                self._module.lockf(fileno, lockflag)
+        except IOError:
+            os.close(fileno)
+            if not wait:
+                # this is typically
+                # "[Errno 35] Resource temporarily unavailable",
+                # because of LOCK_NB
+                return False
+            else:
+                raise
+        else:
+            self._filedescriptor = fileno
+            return True
+
+    def _release(self):
+        if self._filedescriptor is None:
+            return
+        if self.key_offset is not None:
+            self._module.lockf(self._filedescriptor, self._module.LOCK_UN, 1, self.key_offset)
+        else:
+            self._module.lockf(self._filedescriptor, self._module.LOCK_UN)
+        os.close(self._filedescriptor)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     dogpile.cache = dogpile.cache.plugins.mako_cache:MakoPlugin
     """,
     zip_safe=False,
-    install_requires=['decorator'],
+    install_requires=['decorator', 'pytz'],
     tests_require=['pytest', 'pytest-cov', 'mock', 'Mako'],
     cmdclass={'test': PyTest},
 )

--- a/tests/cache/test_files_backend.py
+++ b/tests/cache/test_files_backend.py
@@ -1,0 +1,66 @@
+from ._fixtures import _GenericBackendTest, _GenericMutexTest
+from . import assert_raises_message
+import os
+import sys
+
+try:
+    import fcntl  # noqa
+    has_fcntl = True
+except ImportError:
+    has_fcntl = False
+
+
+test_basedir = "test_%s.db" % sys.hexversion
+
+if has_fcntl:
+    class FilesBackendTest(_GenericBackendTest):
+        backend = "dogpile.cache.files"
+
+        config_args = {
+            "arguments": {
+                "base_dir": test_basedir,
+            }
+        }
+
+
+class _FilesMutexTest(_GenericMutexTest):
+    backend = "dogpile.cache.files"
+
+    def test_release_assertion_thread(self):
+        backend = self._backend()
+        m1 = backend.get_mutex("foo")
+        assert_raises_message(
+            AssertionError,
+            "this thread didn't do the acquire",
+            m1.release
+        )
+
+    def test_release_assertion_key(self):
+        backend = self._backend()
+        m1 = backend.get_mutex("foo")
+        m2 = backend.get_mutex("bar")
+
+        m1.acquire()
+        try:
+            assert_raises_message(
+                AssertionError,
+                "No acquire held for key 'bar'",
+                m2.release
+            )
+        finally:
+            m1.release()
+
+if has_fcntl:
+    class FilesMutexFileTest(_FilesMutexTest):
+        config_args = {
+            "arguments": {
+                "base_dir": test_basedir,
+                'distributed_lock': True,
+            }
+        }
+
+
+def teardown():
+    for fname in os.listdir(os.curdir):
+        if fname.startswith(test_basedir):
+            os.rmdir(fname)


### PR DESCRIPTION
This PR is the implementation of the solution proposed in #141.
Specifically, I implemented the RangedFileLock class that allows to use 1 lock file for multiple keys (available only on platforms that have `fcntl`, just like FileLock).
I also introduced a new backend, `FilesBackend`. This backend will work just like DBMBackend, with the following differences:

- it can also be used to store files directly, without the need of keeping the content of the file in memory.
- it does not use a DBM file, it just stores to 3 files for each key (we can actually just store 2 of them)

This code is by no means clean yet, but I just wanted early feedback.
Also the test suite is not complete and it fails when testing the mutex returned by `FilesBackend.get_mutex()`, since this is a re-entrant mutex in the context of the process.

I would like to know what you think @zzzeek.
