### PR TITLE
Format code for PEP8 compliance.

### DIFF
--- a/dogpile/__init__.py
+++ b/dogpile/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.2'
+__version__ = "0.7.2"
 
 from .lock import Lock  # noqa
 from .lock import NeedRegenerationException  # noqa

--- a/dogpile/cache/__init__.py
+++ b/dogpile/cache/__init__.py
@@ -1,4 +1,6 @@
-from .region import CacheRegion, register_backend, make_region  # noqa
+from .region import CacheRegion  # noqa
+from .region import make_region  # noqa
+from .region import register_backend  # noqa
+from .. import __version__  # noqa
 
 # backwards compat
-from .. import __version__  # noqa

--- a/dogpile/cache/api.py
+++ b/dogpile/cache/api.py
@@ -1,4 +1,5 @@
 import operator
+
 from ..util.compat import py3k
 
 
@@ -9,6 +10,7 @@ class NoValue(object):
     should be used.
 
     """
+
     @property
     def payload(self):
         return self
@@ -18,12 +20,15 @@ class NoValue(object):
         fill another cache key.
 
         """
-        return '<dogpile.cache.api.NoValue object>'
+        return "<dogpile.cache.api.NoValue object>"
 
     if py3k:
+
         def __bool__(self):  # pragma NO COVERAGE
             return False
+
     else:
+
         def __nonzero__(self):  # pragma NO COVERAGE
             return False
 
@@ -44,6 +49,7 @@ class CachedValue(tuple):
     the backend requires serialization.
 
     """
+
     payload = property(operator.itemgetter(0))
     """Named accessor for the payload."""
 

--- a/dogpile/cache/backends/__init__.py
+++ b/dogpile/cache/backends/__init__.py
@@ -4,22 +4,34 @@ _backend_loader = PluginLoader("dogpile.cache")
 register_backend = _backend_loader.register
 
 register_backend(
-    "dogpile.cache.null", "dogpile.cache.backends.null", "NullBackend")
+    "dogpile.cache.null", "dogpile.cache.backends.null", "NullBackend"
+)
 register_backend(
-    "dogpile.cache.dbm", "dogpile.cache.backends.file", "DBMBackend")
+    "dogpile.cache.dbm", "dogpile.cache.backends.file", "DBMBackend"
+)
 register_backend(
-    "dogpile.cache.pylibmc", "dogpile.cache.backends.memcached",
-    "PylibmcBackend")
+    "dogpile.cache.pylibmc",
+    "dogpile.cache.backends.memcached",
+    "PylibmcBackend",
+)
 register_backend(
-    "dogpile.cache.bmemcached", "dogpile.cache.backends.memcached",
-    "BMemcachedBackend")
+    "dogpile.cache.bmemcached",
+    "dogpile.cache.backends.memcached",
+    "BMemcachedBackend",
+)
 register_backend(
-    "dogpile.cache.memcached", "dogpile.cache.backends.memcached",
-    "MemcachedBackend")
+    "dogpile.cache.memcached",
+    "dogpile.cache.backends.memcached",
+    "MemcachedBackend",
+)
 register_backend(
-    "dogpile.cache.memory", "dogpile.cache.backends.memory", "MemoryBackend")
+    "dogpile.cache.memory", "dogpile.cache.backends.memory", "MemoryBackend"
+)
 register_backend(
-    "dogpile.cache.memory_pickle", "dogpile.cache.backends.memory",
-    "MemoryPickleBackend")
+    "dogpile.cache.memory_pickle",
+    "dogpile.cache.backends.memory",
+    "MemoryPickleBackend",
+)
 register_backend(
-    "dogpile.cache.redis", "dogpile.cache.backends.redis", "RedisBackend")
+    "dogpile.cache.redis", "dogpile.cache.backends.redis", "RedisBackend"
+)

--- a/dogpile/cache/backends/file.py
+++ b/dogpile/cache/backends/file.py
@@ -7,13 +7,16 @@ Provides backends that deal with local filesystem access.
 """
 
 from __future__ import with_statement
-from ..api import CacheBackend, NO_VALUE
+
 from contextlib import contextmanager
-from ...util import compat
-from ... import util
 import os
 
-__all__ = 'DBMBackend', 'FileLock', 'AbstractFileLock'
+from ..api import CacheBackend
+from ..api import NO_VALUE
+from ... import util
+from ...util import compat
+
+__all__ = "DBMBackend", "FileLock", "AbstractFileLock"
 
 
 class DBMBackend(CacheBackend):
@@ -134,21 +137,24 @@ class DBMBackend(CacheBackend):
 
 
     """
+
     def __init__(self, arguments):
         self.filename = os.path.abspath(
-            os.path.normpath(arguments['filename'])
+            os.path.normpath(arguments["filename"])
         )
         dir_, filename = os.path.split(self.filename)
 
         self.lock_factory = arguments.get("lock_factory", FileLock)
         self._rw_lock = self._init_lock(
-            arguments.get('rw_lockfile'),
-            ".rw.lock", dir_, filename)
+            arguments.get("rw_lockfile"), ".rw.lock", dir_, filename
+        )
         self._dogpile_lock = self._init_lock(
-            arguments.get('dogpile_lockfile'),
+            arguments.get("dogpile_lockfile"),
             ".dogpile.lock",
-            dir_, filename,
-            util.KeyReentrantMutex.factory)
+            dir_,
+            filename,
+            util.KeyReentrantMutex.factory,
+        )
 
         # TODO: make this configurable
         if compat.py3k:
@@ -163,9 +169,8 @@ class DBMBackend(CacheBackend):
             lock = self.lock_factory(os.path.join(basedir, basefile + suffix))
         elif argument is not False:
             lock = self.lock_factory(
-                os.path.abspath(
-                    os.path.normpath(argument)
-                ))
+                os.path.abspath(os.path.normpath(argument))
+            )
         else:
             return None
         if wrapper:
@@ -175,12 +180,12 @@ class DBMBackend(CacheBackend):
     def _init_dbm_file(self):
         exists = os.access(self.filename, os.F_OK)
         if not exists:
-            for ext in ('db', 'dat', 'pag', 'dir'):
+            for ext in ("db", "dat", "pag", "dir"):
                 if os.access(self.filename + os.extsep + ext, os.F_OK):
                     exists = True
                     break
         if not exists:
-            fh = self.dbmmodule.open(self.filename, 'c')
+            fh = self.dbmmodule.open(self.filename, "c")
             fh.close()
 
     def get_mutex(self, key):
@@ -210,15 +215,13 @@ class DBMBackend(CacheBackend):
     @contextmanager
     def _dbm_file(self, write):
         with self._use_rw_lock(write):
-            dbm = self.dbmmodule.open(
-                self.filename,
-                "w" if write else "r")
+            dbm = self.dbmmodule.open(self.filename, "w" if write else "r")
             yield dbm
             dbm.close()
 
     def get(self, key):
         with self._dbm_file(False) as dbm:
-            if hasattr(dbm, 'get'):
+            if hasattr(dbm, "get"):
                 value = dbm.get(key, NO_VALUE)
             else:
                 # gdbm objects lack a .get method
@@ -235,14 +238,16 @@ class DBMBackend(CacheBackend):
 
     def set(self, key, value):
         with self._dbm_file(True) as dbm:
-            dbm[key] = compat.pickle.dumps(value,
-                                           compat.pickle.HIGHEST_PROTOCOL)
+            dbm[key] = compat.pickle.dumps(
+                value, compat.pickle.HIGHEST_PROTOCOL
+            )
 
     def set_multi(self, mapping):
         with self._dbm_file(True) as dbm:
             for key, value in mapping.items():
-                dbm[key] = compat.pickle.dumps(value,
-                                               compat.pickle.HIGHEST_PROTOCOL)
+                dbm[key] = compat.pickle.dumps(
+                    value, compat.pickle.HIGHEST_PROTOCOL
+                )
 
     def delete(self, key):
         with self._dbm_file(True) as dbm:
@@ -398,11 +403,12 @@ class FileLock(AbstractFileLock):
     @util.memoized_property
     def _module(self):
         import fcntl
+
         return fcntl
 
     @property
     def is_open(self):
-        return hasattr(self._filedescriptor, 'fileno')
+        return hasattr(self._filedescriptor, "fileno")
 
     def acquire_read_lock(self, wait):
         return self._acquire(wait, os.O_RDONLY, self._module.LOCK_SH)

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -6,14 +6,21 @@ Provides backends for talking to `memcached <http://memcached.org>`_.
 
 """
 
-from ..api import CacheBackend, NO_VALUE
-from ...util import compat
-from ... import util
 import random
 import time
 
-__all__ = 'GenericMemcachedBackend', 'MemcachedBackend',\
-          'PylibmcBackend', 'BMemcachedBackend', 'MemcachedLock'
+from ..api import CacheBackend
+from ..api import NO_VALUE
+from ... import util
+from ...util import compat
+
+__all__ = (
+    "GenericMemcachedBackend",
+    "MemcachedBackend",
+    "PylibmcBackend",
+    "BMemcachedBackend",
+    "MemcachedLock",
+)
 
 
 class MemcachedLock(object):
@@ -111,11 +118,10 @@ class GenericMemcachedBackend(CacheBackend):
         # so the idea is that this is superior to pylibmc's
         # own ThreadMappedPool which doesn't handle this
         # automatically.
-        self.url = util.to_list(arguments['url'])
-        self.distributed_lock = arguments.get('distributed_lock', False)
-        self.lock_timeout = arguments.get('lock_timeout', 0)
-        self.memcached_expire_time = arguments.get(
-            'memcached_expire_time', 0)
+        self.url = util.to_list(arguments["url"])
+        self.distributed_lock = arguments.get("distributed_lock", False)
+        self.lock_timeout = arguments.get("lock_timeout", 0)
+        self.memcached_expire_time = arguments.get("memcached_expire_time", 0)
 
     def has_lock_timeout(self):
         return self.lock_timeout != 0
@@ -152,8 +158,9 @@ class GenericMemcachedBackend(CacheBackend):
 
     def get_mutex(self, key):
         if self.distributed_lock:
-            return MemcachedLock(lambda: self.client, key,
-                                 timeout=self.lock_timeout)
+            return MemcachedLock(
+                lambda: self.client, key, timeout=self.lock_timeout
+            )
         else:
             return None
 
@@ -166,23 +173,13 @@ class GenericMemcachedBackend(CacheBackend):
 
     def get_multi(self, keys):
         values = self.client.get_multi(keys)
-        return [
-            NO_VALUE if key not in values
-            else values[key] for key in keys
-        ]
+        return [NO_VALUE if key not in values else values[key] for key in keys]
 
     def set(self, key, value):
-        self.client.set(
-            key,
-            value,
-            **self.set_arguments
-        )
+        self.client.set(key, value, **self.set_arguments)
 
     def set_multi(self, mapping):
-        self.client.set_multi(
-            mapping,
-            **self.set_arguments
-        )
+        self.client.set_multi(mapping, **self.set_arguments)
 
     def delete(self, key):
         self.client.delete(key)
@@ -196,16 +193,19 @@ class MemcacheArgs(object):
     'min_compress_len' to other methods.
 
     """
+
     def __init__(self, arguments):
-        self.min_compress_len = arguments.get('min_compress_len', 0)
+        self.min_compress_len = arguments.get("min_compress_len", 0)
 
         self.set_arguments = {}
         if "memcached_expire_time" in arguments:
             self.set_arguments["time"] = arguments["memcached_expire_time"]
         if "min_compress_len" in arguments:
-            self.set_arguments["min_compress_len"] = \
-                arguments["min_compress_len"]
+            self.set_arguments["min_compress_len"] = arguments[
+                "min_compress_len"
+            ]
         super(MemcacheArgs, self).__init__(arguments)
+
 
 pylibmc = None
 
@@ -245,8 +245,8 @@ class PylibmcBackend(MemcacheArgs, GenericMemcachedBackend):
     """
 
     def __init__(self, arguments):
-        self.binary = arguments.get('binary', False)
-        self.behaviors = arguments.get('behaviors', {})
+        self.binary = arguments.get("binary", False)
+        self.behaviors = arguments.get("behaviors", {})
         super(PylibmcBackend, self).__init__(arguments)
 
     def _imports(self):
@@ -255,10 +255,9 @@ class PylibmcBackend(MemcacheArgs, GenericMemcachedBackend):
 
     def _create_client(self):
         return pylibmc.Client(
-            self.url,
-            binary=self.binary,
-            behaviors=self.behaviors
+            self.url, binary=self.binary, behaviors=self.behaviors
         )
+
 
 memcache = None
 
@@ -282,6 +281,7 @@ class MemcachedBackend(MemcacheArgs, GenericMemcachedBackend):
         )
 
     """
+
     def _imports(self):
         global memcache
         import memcache  # noqa
@@ -326,9 +326,10 @@ class BMemcachedBackend(GenericMemcachedBackend):
      SASL authentication.
 
     """
+
     def __init__(self, arguments):
-        self.username = arguments.get('username', None)
-        self.password = arguments.get('password', None)
+        self.username = arguments.get("username", None)
+        self.password = arguments.get("password", None)
         super(BMemcachedBackend, self).__init__(arguments)
 
     def _imports(self):
@@ -345,7 +346,8 @@ class BMemcachedBackend(GenericMemcachedBackend):
             def add(self, key, value, timeout=0):
                 try:
                     return super(RepairBMemcachedAPI, self).add(
-                        key, value, timeout)
+                        key, value, timeout
+                    )
                 except ValueError:
                     return False
 
@@ -353,9 +355,7 @@ class BMemcachedBackend(GenericMemcachedBackend):
 
     def _create_client(self):
         return self.Client(
-            self.url,
-            username=self.username,
-            password=self.password
+            self.url, username=self.username, password=self.password
         )
 
     def delete_multi(self, keys):

--- a/dogpile/cache/backends/memory.py
+++ b/dogpile/cache/backends/memory.py
@@ -10,7 +10,8 @@ places the value as given into the dictionary.
 
 """
 
-from ..api import CacheBackend, NO_VALUE
+from ..api import CacheBackend
+from ..api import NO_VALUE
 from ...util.compat import pickle
 
 
@@ -47,6 +48,7 @@ class MemoryBackend(CacheBackend):
 
 
     """
+
     pickle_values = False
 
     def __init__(self, arguments):
@@ -59,13 +61,10 @@ class MemoryBackend(CacheBackend):
         return value
 
     def get_multi(self, keys):
-        ret = [
-            self._cache.get(key, NO_VALUE)
-            for key in keys]
+        ret = [self._cache.get(key, NO_VALUE) for key in keys]
         if self.pickle_values:
             ret = [
-                pickle.loads(value)
-                if value is not NO_VALUE else value
+                pickle.loads(value) if value is not NO_VALUE else value
                 for value in ret
             ]
         return ret
@@ -121,4 +120,5 @@ class MemoryPickleBackend(MemoryBackend):
     .. versionadded:: 0.5.3
 
     """
+
     pickle_values = True

--- a/dogpile/cache/backends/null.py
+++ b/dogpile/cache/backends/null.py
@@ -10,10 +10,11 @@ caching for a region that is otherwise used normally.
 
 """
 
-from ..api import CacheBackend, NO_VALUE
+from ..api import CacheBackend
+from ..api import NO_VALUE
 
 
-__all__ = ['NullBackend']
+__all__ = ["NullBackend"]
 
 
 class NullLock(object):

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -7,12 +7,15 @@ Provides backends for talking to `Redis <http://redis.io>`_.
 """
 
 from __future__ import absolute_import
-from ..api import CacheBackend, NO_VALUE
-from ...util.compat import pickle, u
+
+from ..api import CacheBackend
+from ..api import NO_VALUE
+from ...util.compat import pickle
+from ...util.compat import u
 
 redis = None
 
-__all__ = 'RedisBackend',
+__all__ = ("RedisBackend",)
 
 
 class RedisBackend(CacheBackend):
@@ -93,19 +96,19 @@ class RedisBackend(CacheBackend):
     def __init__(self, arguments):
         arguments = arguments.copy()
         self._imports()
-        self.url = arguments.pop('url', None)
-        self.host = arguments.pop('host', 'localhost')
-        self.password = arguments.pop('password', None)
-        self.port = arguments.pop('port', 6379)
-        self.db = arguments.pop('db', 0)
-        self.distributed_lock = arguments.get('distributed_lock', False)
-        self.socket_timeout = arguments.pop('socket_timeout', None)
+        self.url = arguments.pop("url", None)
+        self.host = arguments.pop("host", "localhost")
+        self.password = arguments.pop("password", None)
+        self.port = arguments.pop("port", 6379)
+        self.db = arguments.pop("db", 0)
+        self.distributed_lock = arguments.get("distributed_lock", False)
+        self.socket_timeout = arguments.pop("socket_timeout", None)
 
-        self.lock_timeout = arguments.get('lock_timeout', None)
-        self.lock_sleep = arguments.get('lock_sleep', 0.1)
+        self.lock_timeout = arguments.get("lock_timeout", None)
+        self.lock_sleep = arguments.get("lock_sleep", 0.1)
 
-        self.redis_expiration_time = arguments.pop('redis_expiration_time', 0)
-        self.connection_pool = arguments.get('connection_pool', None)
+        self.redis_expiration_time = arguments.pop("redis_expiration_time", 0)
+        self.connection_pool = arguments.get("connection_pool", None)
         self.client = self._create_client()
 
     def _imports(self):
@@ -122,22 +125,25 @@ class RedisBackend(CacheBackend):
 
         args = {}
         if self.socket_timeout:
-            args['socket_timeout'] = self.socket_timeout
+            args["socket_timeout"] = self.socket_timeout
 
         if self.url is not None:
             args.update(url=self.url)
             return redis.StrictRedis.from_url(**args)
         else:
             args.update(
-                host=self.host, password=self.password,
-                port=self.port, db=self.db
+                host=self.host,
+                password=self.password,
+                port=self.port,
+                db=self.db,
             )
             return redis.StrictRedis(**args)
 
     def get_mutex(self, key):
         if self.distributed_lock:
-            return self.client.lock(u('_lock{0}').format(key),
-                                    self.lock_timeout, self.lock_sleep)
+            return self.client.lock(
+                u("_lock{0}").format(key), self.lock_timeout, self.lock_sleep
+            )
         else:
             return None
 
@@ -151,14 +157,15 @@ class RedisBackend(CacheBackend):
         if not keys:
             return []
         values = self.client.mget(keys)
-        return [
-            pickle.loads(v) if v is not None else NO_VALUE
-            for v in values]
+        return [pickle.loads(v) if v is not None else NO_VALUE for v in values]
 
     def set(self, key, value):
         if self.redis_expiration_time:
-            self.client.setex(key, self.redis_expiration_time,
-                              pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
+            self.client.setex(
+                key,
+                self.redis_expiration_time,
+                pickle.dumps(value, pickle.HIGHEST_PROTOCOL),
+            )
         else:
             self.client.set(key, pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
 

--- a/dogpile/cache/plugins/mako_cache.py
+++ b/dogpile/cache/plugins/mako_cache.py
@@ -51,20 +51,22 @@ class MakoPlugin(CacheImpl):
     def __init__(self, cache):
         super(MakoPlugin, self).__init__(cache)
         try:
-            self.regions = self.cache.template.cache_args['regions']
+            self.regions = self.cache.template.cache_args["regions"]
         except KeyError:
             raise KeyError(
                 "'cache_regions' argument is required on the "
                 "Mako Lookup or Template object for usage "
-                "with the dogpile.cache plugin.")
+                "with the dogpile.cache plugin."
+            )
 
     def _get_region(self, **kw):
         try:
-            region = kw['region']
+            region = kw["region"]
         except KeyError:
             raise KeyError(
                 "'cache_region' argument must be specified with 'cache=True'"
-                "within templates for usage with the dogpile.cache plugin.")
+                "within templates for usage with the dogpile.cache plugin."
+            )
         try:
             return self.regions[region]
         except KeyError:
@@ -73,8 +75,8 @@ class MakoPlugin(CacheImpl):
     def get_and_replace(self, key, creation_function, **kw):
         expiration_time = kw.pop("timeout", None)
         return self._get_region(**kw).get_or_create(
-            key, creation_function,
-            expiration_time=expiration_time)
+            key, creation_function, expiration_time=expiration_time
+        )
 
     def get_or_create(self, key, creation_function, **kw):
         return self.get_and_replace(key, creation_function, **kw)

--- a/dogpile/cache/proxy.py
+++ b/dogpile/cache/proxy.py
@@ -59,13 +59,13 @@ class ProxyBackend(CacheBackend):
         self.proxied = None
 
     def wrap(self, backend):
-        ''' Take a backend as an argument and setup the self.proxied property.
+        """ Take a backend as an argument and setup the self.proxied property.
         Return an object that be used as a backend by a :class:`.CacheRegion`
         object.
-        '''
-        assert(
-            isinstance(backend, CacheBackend) or
-            isinstance(backend, ProxyBackend))
+        """
+        assert isinstance(backend, CacheBackend) or isinstance(
+            backend, ProxyBackend
+        )
         self.proxied = backend
         return self
 

--- a/dogpile/cache/region.py
+++ b/dogpile/cache/region.py
@@ -1,22 +1,29 @@
 from __future__ import with_statement
-from .. import Lock, NeedRegenerationException
-from ..util import NameRegistry
-from . import exception
-from ..util import PluginLoader, memoized_property, coerce_string_conf
-from .util import function_key_generator, function_multi_key_generator
-from .api import NO_VALUE, CachedValue
-from .proxy import ProxyBackend
-from ..util import compat
-import time
+
 import datetime
+from functools import partial
+from functools import wraps
 from numbers import Number
-from functools import wraps, partial
 import threading
+import time
+
 from decorator import decorate
 
-from .backends import register_backend
-from .backends import _backend_loader
-
+from . import exception
+from .api import CachedValue
+from .api import NO_VALUE
+from .backends import register_backend  # noqa nosort
+from .backends import _backend_loader  # noqa nosort
+from .proxy import ProxyBackend
+from .util import function_key_generator
+from .util import function_multi_key_generator
+from .. import Lock
+from .. import NeedRegenerationException
+from ..util import coerce_string_conf
+from ..util import compat
+from ..util import memoized_property
+from ..util import NameRegistry
+from ..util import PluginLoader
 
 value_version = 1
 """An integer placed in the :class:`.CachedValue`
@@ -74,7 +81,7 @@ class RegionInvalidationStrategy(object):
 
         region = CacheRegion()
 
-        region = region.configure(region_invalidator=CustomInvalidationStrategy())
+        region = region.configure(region_invalidator=CustomInvalidationStrategy())  # noqa
 
     Invalidation strategies that wish to have access to the
     :class:`.CacheRegion` itself should construct the invalidator given the
@@ -162,7 +169,6 @@ class RegionInvalidationStrategy(object):
 
 
 class DefaultInvalidationStrategy(RegionInvalidationStrategy):
-
     def __init__(self):
         self._is_hard_invalidated = None
         self._invalidated = None
@@ -172,8 +178,7 @@ class DefaultInvalidationStrategy(RegionInvalidationStrategy):
         self._invalidated = time.time()
 
     def is_invalidated(self, timestamp):
-        return (self._invalidated is not None and
-                timestamp < self._invalidated)
+        return self._invalidated is not None and timestamp < self._invalidated
 
     def was_hard_invalidated(self):
         return self._is_hard_invalidated is True
@@ -328,12 +333,12 @@ class CacheRegion(object):
     """
 
     def __init__(
-            self,
-            name=None,
-            function_key_generator=function_key_generator,
-            function_multi_key_generator=function_multi_key_generator,
-            key_mangler=None,
-            async_creation_runner=None,
+        self,
+        name=None,
+        function_key_generator=function_key_generator,
+        function_multi_key_generator=function_multi_key_generator,
+        key_mangler=None,
+        async_creation_runner=None,
     ):
         """Construct a new :class:`.CacheRegion`."""
         self.name = name
@@ -344,14 +349,15 @@ class CacheRegion(object):
         self.region_invalidator = DefaultInvalidationStrategy()
 
     def configure(
-            self, backend,
-            expiration_time=None,
-            arguments=None,
-            _config_argument_dict=None,
-            _config_prefix=None,
-            wrap=None,
-            replace_existing_backend=False,
-            region_invalidator=None
+        self,
+        backend,
+        expiration_time=None,
+        arguments=None,
+        _config_argument_dict=None,
+        _config_prefix=None,
+        wrap=None,
+        replace_existing_backend=False,
+        region_invalidator=None,
     ):
         """Configure a :class:`.CacheRegion`.
 
@@ -410,18 +416,19 @@ class CacheRegion(object):
                 "This region is already "
                 "configured with backend: %s.  "
                 "Specify replace_existing_backend=True to replace."
-                % self.backend)
+                % self.backend
+            )
 
         try:
             backend_cls = _backend_loader.load(backend)
         except PluginLoader.NotFound:
             raise exception.PluginNotFound(
-                "Couldn't find cache plugin to load: %s" % backend)
+                "Couldn't find cache plugin to load: %s" % backend
+            )
 
         if _config_argument_dict:
             self.backend = backend_cls.from_config_dict(
-                _config_argument_dict,
-                _config_prefix
+                _config_argument_dict, _config_prefix
             )
         else:
             self.backend = backend_cls(arguments or {})
@@ -430,17 +437,19 @@ class CacheRegion(object):
             self.expiration_time = expiration_time
         elif isinstance(expiration_time, datetime.timedelta):
             self.expiration_time = int(
-                compat.timedelta_total_seconds(expiration_time))
+                compat.timedelta_total_seconds(expiration_time)
+            )
         else:
             raise exception.ValidationError(
-                'expiration_time is not a number or timedelta.')
+                "expiration_time is not a number or timedelta."
+            )
 
         if not self._user_defined_key_mangler:
             self.key_mangler = self.backend.key_mangler
 
         self._lock_registry = NameRegistry(self._create_mutex)
 
-        if getattr(wrap, '__iter__', False):
+        if getattr(wrap, "__iter__", False):
             for wrapper in reversed(wrap):
                 self.wrap(wrapper)
 
@@ -450,8 +459,8 @@ class CacheRegion(object):
         return self
 
     def wrap(self, proxy):
-        ''' Takes a ProxyBackend instance or class and wraps the
-        attached backend. '''
+        """ Takes a ProxyBackend instance or class and wraps the
+        attached backend. """
 
         # if we were passed a type rather than an instance then
         # initialize it.
@@ -459,8 +468,9 @@ class CacheRegion(object):
             proxy = proxy()
 
         if not issubclass(type(proxy), ProxyBackend):
-            raise TypeError("Type %s is not a valid ProxyBackend"
-                            % type(proxy))
+            raise TypeError(
+                "Type %s is not a valid ProxyBackend" % type(proxy)
+            )
 
         self.backend = proxy.wrap(self.backend)
 
@@ -469,6 +479,7 @@ class CacheRegion(object):
 
     class _LockWrapper(object):
         """weakref-capable wrapper for threading.Lock"""
+
         def __init__(self):
             self.lock = threading.Lock()
 
@@ -500,7 +511,7 @@ class CacheRegion(object):
         """
         if self._actual_backend is None:
             _backend = self.backend
-            while hasattr(_backend, 'proxied'):
+            while hasattr(_backend, "proxied"):
                 _backend = _backend.proxied
             self._actual_backend = _backend
         return self._actual_backend
@@ -583,19 +594,21 @@ class CacheRegion(object):
         return self.configure(
             config_dict["%sbackend" % prefix],
             expiration_time=config_dict.get(
-                "%sexpiration_time" % prefix, None),
+                "%sexpiration_time" % prefix, None
+            ),
             _config_argument_dict=config_dict,
             _config_prefix="%sarguments." % prefix,
-            wrap=config_dict.get(
-                "%swrap" % prefix, None),
+            wrap=config_dict.get("%swrap" % prefix, None),
             replace_existing_backend=config_dict.get(
-                "%sreplace_existing_backend" % prefix, False),
+                "%sreplace_existing_backend" % prefix, False
+            ),
         )
 
     @memoized_property
     def backend(self):
         raise exception.RegionNotConfigured(
-            "No backend is configured on this region.")
+            "No backend is configured on this region."
+        )
 
     @property
     def is_configured(self):
@@ -605,7 +618,7 @@ class CacheRegion(object):
         .. versionadded:: 0.5.1
 
         """
-        return 'backend' in self.__dict__
+        return "backend" in self.__dict__
 
     def get(self, key, expiration_time=None, ignore_expiration=False):
         """Return a value from the cache, based on the given key.
@@ -682,8 +695,9 @@ class CacheRegion(object):
         if self.key_mangler:
             key = self.key_mangler(key)
         value = self.backend.get(key)
-        value = self._unexpired_value_fn(
-            expiration_time, ignore_expiration)(value)
+        value = self._unexpired_value_fn(expiration_time, ignore_expiration)(
+            value
+        )
 
         return value.payload
 
@@ -699,11 +713,14 @@ class CacheRegion(object):
             def value_fn(value):
                 if value is NO_VALUE:
                     return value
-                elif expiration_time is not None and \
-                        current_time - value.metadata["ct"] > expiration_time:
+                elif (
+                    expiration_time is not None
+                    and current_time - value.metadata["ct"] > expiration_time
+                ):
                     return NO_VALUE
                 elif self.region_invalidator.is_invalidated(
-                        value.metadata["ct"]):
+                    value.metadata["ct"]
+                ):
                     return NO_VALUE
                 else:
                     return value
@@ -751,19 +768,23 @@ class CacheRegion(object):
         backend_values = self.backend.get_multi(keys)
 
         _unexpired_value_fn = self._unexpired_value_fn(
-            expiration_time, ignore_expiration)
+            expiration_time, ignore_expiration
+        )
         return [
             value.payload if value is not NO_VALUE else value
-            for value in
-            (
-                _unexpired_value_fn(value) for value in
-                backend_values
+            for value in (
+                _unexpired_value_fn(value) for value in backend_values
             )
         ]
 
     def get_or_create(
-            self, key, creator, expiration_time=None, should_cache_fn=None,
-            creator_args=None):
+        self,
+        key,
+        creator,
+        expiration_time=None,
+        should_cache_fn=None,
+        creator_args=None,
+    ):
         """Return a cached value based on the given key.
 
         If the value does not exist or is considered to be expired
@@ -851,13 +872,17 @@ class CacheRegion(object):
 
         def get_value():
             value = self.backend.get(key)
-            if (value is NO_VALUE or value.metadata['v'] != value_version or
-                    self.region_invalidator.is_hard_invalidated(
-                        value.metadata["ct"])):
+            if (
+                value is NO_VALUE
+                or value.metadata["v"] != value_version
+                or self.region_invalidator.is_hard_invalidated(
+                    value.metadata["ct"]
+                )
+            ):
                 raise NeedRegenerationException()
             ct = value.metadata["ct"]
             if self.region_invalidator.is_soft_invalidated(ct):
-                ct = time.time() - expiration_time - .0001
+                ct = time.time() - expiration_time - 0.0001
 
             return value.payload, ct
 
@@ -868,8 +893,7 @@ class CacheRegion(object):
                 created_value = creator()
             value = self._value(created_value)
 
-            if not should_cache_fn or \
-                    should_cache_fn(created_value):
+            if not should_cache_fn or should_cache_fn(created_value):
                 self.backend.set(key, value)
 
             return value.payload, value.metadata["ct"]
@@ -877,37 +901,45 @@ class CacheRegion(object):
         if expiration_time is None:
             expiration_time = self.expiration_time
 
-        if (expiration_time is None and
-                self.region_invalidator.was_soft_invalidated()):
+        if (
+            expiration_time is None
+            and self.region_invalidator.was_soft_invalidated()
+        ):
             raise exception.DogpileCacheException(
-                "Non-None expiration time required "
-                "for soft invalidation")
+                "Non-None expiration time required " "for soft invalidation"
+            )
 
         if expiration_time == -1:
             expiration_time = None
 
         if self.async_creation_runner:
+
             def async_creator(mutex):
                 if creator_args:
+
                     @wraps(creator)
                     def go():
                         return creator(*creator_args[0], **creator_args[1])
+
                 else:
                     go = creator
                 return self.async_creation_runner(self, orig_key, go, mutex)
+
         else:
             async_creator = None
 
         with Lock(
-                self._mutex(key),
-                gen_value,
-                get_value,
-                expiration_time,
-                async_creator) as value:
+            self._mutex(key),
+            gen_value,
+            get_value,
+            expiration_time,
+            async_creator,
+        ) as value:
             return value
 
     def get_or_create_multi(
-            self, keys, creator, expiration_time=None, should_cache_fn=None):
+        self, keys, creator, expiration_time=None, should_cache_fn=None
+    ):
         """Return a sequence of cached values based on a sequence of keys.
 
         The behavior for generation of values based on keys corresponds
@@ -956,9 +988,13 @@ class CacheRegion(object):
         def get_value(key):
             value = values.get(key, NO_VALUE)
 
-            if (value is NO_VALUE or value.metadata['v'] != value_version or
-                    self.region_invalidator.is_hard_invalidated(
-                        value.metadata['ct'])):
+            if (
+                value is NO_VALUE
+                or value.metadata["v"] != value_version
+                or self.region_invalidator.is_hard_invalidated(
+                    value.metadata["ct"]
+                )
+            ):
                 # dogpile.core understands a 0 here as
                 # "the value is not available", e.g.
                 # _has_value() will return False.
@@ -966,7 +1002,7 @@ class CacheRegion(object):
             else:
                 ct = value.metadata["ct"]
                 if self.region_invalidator.is_soft_invalidated(ct):
-                    ct = time.time() - expiration_time - .0001
+                    ct = time.time() - expiration_time - 0.0001
 
                 return value.payload, ct
 
@@ -979,11 +1015,13 @@ class CacheRegion(object):
         if expiration_time is None:
             expiration_time = self.expiration_time
 
-        if (expiration_time is None and
-                self.region_invalidator.was_soft_invalidated()):
+        if (
+            expiration_time is None
+            and self.region_invalidator.was_soft_invalidated()
+        ):
             raise exception.DogpileCacheException(
-                "Non-None expiration time required "
-                "for soft invalidation")
+                "Non-None expiration time required " "for soft invalidation"
+            )
 
         if expiration_time == -1:
             expiration_time = None
@@ -1003,11 +1041,11 @@ class CacheRegion(object):
 
         for orig_key, mangled_key in orig_to_mangled.items():
             with Lock(
-                    self._mutex(mangled_key),
-                    gen_value,
-                    lambda: get_value(mangled_key),
-                    expiration_time,
-                    async_creator=lambda mutex: async_creator(orig_key, mutex)
+                self._mutex(mangled_key),
+                gen_value,
+                lambda: get_value(mangled_key),
+                expiration_time,
+                async_creator=lambda mutex: async_creator(orig_key, mutex),
             ):
                 pass
         try:
@@ -1042,12 +1080,7 @@ class CacheRegion(object):
 
     def _value(self, value):
         """Return a :class:`.CachedValue` given a value."""
-        return CachedValue(
-            value,
-            {
-                "ct": time.time(),
-                "v": value_version
-            })
+        return CachedValue(value, {"ct": time.time(), "v": value_version})
 
     def set(self, key, value):
         """Place a new value in the cache under the given key."""
@@ -1066,9 +1099,10 @@ class CacheRegion(object):
             return
 
         if self.key_mangler:
-            mapping = dict((
-                self.key_mangler(k), self._value(v))
-                for k, v in mapping.items())
+            mapping = dict(
+                (self.key_mangler(k), self._value(v))
+                for k, v in mapping.items()
+            )
         else:
             mapping = dict((k, self._value(v)) for k, v in mapping.items())
         self.backend.set_multi(mapping)
@@ -1101,11 +1135,13 @@ class CacheRegion(object):
         self.backend.delete_multi(keys)
 
     def cache_on_arguments(
-            self, namespace=None,
-            expiration_time=None,
-            should_cache_fn=None,
-            to_str=compat.string_type,
-            function_key_generator=None):
+        self,
+        namespace=None,
+        expiration_time=None,
+        should_cache_fn=None,
+        to_str=compat.string_type,
+        function_key_generator=None,
+    ):
         """A function decorator that will cache the return
         value of the function using a key derived from the
         function itself and its arguments.
@@ -1293,10 +1329,14 @@ class CacheRegion(object):
         def get_or_create_for_user_func(key_generator, user_func, *arg, **kw):
             key = key_generator(*arg, **kw)
 
-            timeout = expiration_time() if expiration_time_is_callable \
+            timeout = (
+                expiration_time()
+                if expiration_time_is_callable
                 else expiration_time
-            return self.get_or_create(key, user_func, timeout,
-                                      should_cache_fn, (arg, kw))
+            )
+            return self.get_or_create(
+                key, user_func, timeout, should_cache_fn, (arg, kw)
+            )
 
         def cache_decorator(user_func):
             if to_str is compat.string_type:
@@ -1304,8 +1344,8 @@ class CacheRegion(object):
                 key_generator = function_key_generator(namespace, user_func)
             else:
                 key_generator = function_key_generator(
-                    namespace, user_func,
-                    to_str=to_str)
+                    namespace, user_func, to_str=to_str
+                )
 
             def refresh(*arg, **kw):
                 """
@@ -1336,16 +1376,21 @@ class CacheRegion(object):
 
             # Use `decorate` to preserve the signature of :param:`user_func`.
 
-            return decorate(user_func, partial(
-                get_or_create_for_user_func, key_generator))
+            return decorate(
+                user_func, partial(get_or_create_for_user_func, key_generator)
+            )
 
         return cache_decorator
 
     def cache_multi_on_arguments(
-            self, namespace=None, expiration_time=None,
-            should_cache_fn=None,
-            asdict=False, to_str=compat.string_type,
-            function_multi_key_generator=None):
+        self,
+        namespace=None,
+        expiration_time=None,
+        should_cache_fn=None,
+        asdict=False,
+        to_str=compat.string_type,
+        function_multi_key_generator=None,
+    ):
         """A function decorator that will cache multiple return
         values from the function using a sequence of keys derived from the
         function itself and the arguments passed to it.
@@ -1476,15 +1521,19 @@ class CacheRegion(object):
             def creator(*keys_to_create):
                 return user_func(*[key_lookup[k] for k in keys_to_create])
 
-            timeout = expiration_time() if expiration_time_is_callable \
+            timeout = (
+                expiration_time()
+                if expiration_time_is_callable
                 else expiration_time
+            )
 
             if asdict:
+
                 def dict_create(*keys):
                     d_values = creator(*keys)
                     return [
-                        d_values.get(key_lookup[k], NO_VALUE)
-                        for k in keys]
+                        d_values.get(key_lookup[k], NO_VALUE) for k in keys
+                    ]
 
                 def wrap_cache_fn(value):
                     if value is NO_VALUE:
@@ -1495,21 +1544,24 @@ class CacheRegion(object):
                         return should_cache_fn(value)
 
                 result = self.get_or_create_multi(
-                    keys, dict_create, timeout, wrap_cache_fn)
+                    keys, dict_create, timeout, wrap_cache_fn
+                )
                 result = dict(
-                    (k, v) for k, v in zip(cache_keys, result)
-                    if v is not NO_VALUE)
+                    (k, v)
+                    for k, v in zip(cache_keys, result)
+                    if v is not NO_VALUE
+                )
             else:
                 result = self.get_or_create_multi(
-                    keys, creator, timeout,
-                    should_cache_fn)
+                    keys, creator, timeout, should_cache_fn
+                )
 
             return result
 
         def cache_decorator(user_func):
             key_generator = function_multi_key_generator(
-                namespace, user_func,
-                to_str=to_str)
+                namespace, user_func, to_str=to_str
+            )
 
             def invalidate(*arg):
                 keys = key_generator(*arg)
@@ -1518,10 +1570,11 @@ class CacheRegion(object):
             def set_(mapping):
                 keys = list(mapping)
                 gen_keys = key_generator(*keys)
-                self.set_multi(dict(
-                    (gen_key, mapping[key])
-                    for gen_key, key
-                    in zip(gen_keys, keys))
+                self.set_multi(
+                    dict(
+                        (gen_key, mapping[key])
+                        for gen_key, key in zip(gen_keys, keys)
+                    )
                 )
 
             def get(*arg):
@@ -1532,14 +1585,10 @@ class CacheRegion(object):
                 keys = key_generator(*arg)
                 values = user_func(*arg)
                 if asdict:
-                    self.set_multi(
-                        dict(zip(keys, [values[a] for a in arg]))
-                    )
+                    self.set_multi(dict(zip(keys, [values[a] for a in arg])))
                     return values
                 else:
-                    self.set_multi(
-                        dict(zip(keys, values))
-                    )
+                    self.set_multi(dict(zip(keys, values)))
                     return values
 
             user_func.set = set_
@@ -1549,11 +1598,11 @@ class CacheRegion(object):
 
             # Use `decorate` to preserve the signature of :param:`user_func`.
 
-            return decorate(user_func, partial(get_or_create_for_user_func, key_generator))
+            return decorate(
+                user_func, partial(get_or_create_for_user_func, key_generator)
+            )
 
         return cache_decorator
-
-
 
 
 def make_region(*arg, **kw):

--- a/dogpile/cache/util.py
+++ b/dogpile/cache/util.py
@@ -1,4 +1,5 @@
 from hashlib import sha1
+
 from ..util import compat
 from ..util import langhelpers
 
@@ -23,43 +24,47 @@ def function_key_generator(namespace, fn, to_str=compat.string_type):
     """
 
     if namespace is None:
-        namespace = '%s:%s' % (fn.__module__, fn.__name__)
+        namespace = "%s:%s" % (fn.__module__, fn.__name__)
     else:
-        namespace = '%s:%s|%s' % (fn.__module__, fn.__name__, namespace)
+        namespace = "%s:%s|%s" % (fn.__module__, fn.__name__, namespace)
 
     args = compat.inspect_getargspec(fn)
-    has_self = args[0] and args[0][0] in ('self', 'cls')
+    has_self = args[0] and args[0][0] in ("self", "cls")
 
     def generate_key(*args, **kw):
         if kw:
             raise ValueError(
                 "dogpile.cache's default key creation "
-                "function does not accept keyword arguments.")
+                "function does not accept keyword arguments."
+            )
         if has_self:
             args = args[1:]
 
         return namespace + "|" + " ".join(map(to_str, args))
+
     return generate_key
 
 
 def function_multi_key_generator(namespace, fn, to_str=compat.string_type):
 
     if namespace is None:
-        namespace = '%s:%s' % (fn.__module__, fn.__name__)
+        namespace = "%s:%s" % (fn.__module__, fn.__name__)
     else:
-        namespace = '%s:%s|%s' % (fn.__module__, fn.__name__, namespace)
+        namespace = "%s:%s|%s" % (fn.__module__, fn.__name__, namespace)
 
     args = compat.inspect_getargspec(fn)
-    has_self = args[0] and args[0][0] in ('self', 'cls')
+    has_self = args[0] and args[0][0] in ("self", "cls")
 
     def generate_keys(*args, **kw):
         if kw:
             raise ValueError(
                 "dogpile.cache's default key creation "
-                "function does not accept keyword arguments.")
+                "function does not accept keyword arguments."
+            )
         if has_self:
             args = args[1:]
         return [namespace + "|" + key for key in map(to_str, args)]
+
     return generate_keys
 
 
@@ -83,9 +88,9 @@ def kwarg_function_key_generator(namespace, fn, to_str=compat.string_type):
     """
 
     if namespace is None:
-        namespace = '%s:%s' % (fn.__module__, fn.__name__)
+        namespace = "%s:%s" % (fn.__module__, fn.__name__)
     else:
-        namespace = '%s:%s|%s' % (fn.__module__, fn.__name__, namespace)
+        namespace = "%s:%s|%s" % (fn.__module__, fn.__name__, namespace)
 
     argspec = compat.inspect_getargspec(fn)
     default_list = list(argspec.defaults or [])
@@ -94,26 +99,32 @@ def kwarg_function_key_generator(namespace, fn, to_str=compat.string_type):
     # enumerate()
     default_list.reverse()
     # use idx*-1 to create the correct right-lookup index.
-    args_with_defaults = dict((argspec.args[(idx*-1)], default)
-                              for idx, default in enumerate(default_list, 1))
-    if argspec.args and argspec.args[0] in ('self', 'cls'):
+    args_with_defaults = dict(
+        (argspec.args[(idx * -1)], default)
+        for idx, default in enumerate(default_list, 1)
+    )
+    if argspec.args and argspec.args[0] in ("self", "cls"):
         arg_index_start = 1
     else:
         arg_index_start = 0
 
     def generate_key(*args, **kwargs):
         as_kwargs = dict(
-            [(argspec.args[idx], arg)
-             for idx, arg in enumerate(args[arg_index_start:],
-                                       arg_index_start)])
+            [
+                (argspec.args[idx], arg)
+                for idx, arg in enumerate(
+                    args[arg_index_start:], arg_index_start
+                )
+            ]
+        )
         as_kwargs.update(kwargs)
         for arg, val in args_with_defaults.items():
             if arg not in as_kwargs:
                 as_kwargs[arg] = val
 
-        argument_values = [as_kwargs[key]
-                           for key in sorted(as_kwargs.keys())]
-        return namespace + '|' + " ".join(map(to_str, argument_values))
+        argument_values = [as_kwargs[key] for key in sorted(as_kwargs.keys())]
+        return namespace + "|" + " ".join(map(to_str, argument_values))
+
     return generate_key
 
 
@@ -128,12 +139,15 @@ def length_conditional_mangler(length, mangler):
     past a certain threshold.
 
     """
+
     def mangle(key):
         if len(key) >= length:
             return mangler(key)
         else:
             return key
+
     return mangle
+
 
 # in the 0.6 release these functions were moved to the dogpile.util namespace.
 # They are linked here to maintain compatibility with older versions.

--- a/dogpile/core.py
+++ b/dogpile/core.py
@@ -8,10 +8,10 @@ dogpile.core installation is present.
 
 """
 
-from .util import nameregistry  # noqa
-from .util import readwrite_lock  # noqa
-from .util.readwrite_lock import ReadWriteMutex  # noqa
-from .util.nameregistry import NameRegistry  # noqa
+from . import __version__  # noqa
 from .lock import Lock  # noqa
 from .lock import NeedRegenerationException  # noqa
-from . import __version__ # noqa
+from .util import nameregistry  # noqa
+from .util import readwrite_lock  # noqa
+from .util.nameregistry import NameRegistry  # noqa
+from .util.readwrite_lock import ReadWriteMutex  # noqa

--- a/dogpile/lock.py
+++ b/dogpile/lock.py
@@ -1,5 +1,5 @@
-import time
 import logging
+import time
 
 log = logging.getLogger(__name__)
 
@@ -10,6 +10,7 @@ class NeedRegenerationException(Exception):
     regeneration of the value.
 
     """
+
 
 NOT_REGENERATED = object()
 
@@ -70,8 +71,8 @@ class Lock(object):
         value is available."""
 
         return not self._has_value(createdtime) or (
-            self.expiretime is not None and
-            time.time() - createdtime > self.expiretime
+            self.expiretime is not None
+            and time.time() - createdtime > self.expiretime
         )
 
     def _has_value(self, createdtime):
@@ -109,7 +110,8 @@ class Lock(object):
                 raise Exception(
                     "Generation function should "
                     "have just been called by a concurrent "
-                    "thread.")
+                    "thread."
+                )
         else:
             return value
 
@@ -123,8 +125,8 @@ class Lock(object):
             has_value = True
             if not self.mutex.acquire(False):
                 log.debug(
-                    "creation function in progress "
-                    "elsewhere, returning")
+                    "creation function in progress " "elsewhere, returning"
+                )
                 return NOT_REGENERATED
         else:
             has_value = False
@@ -173,8 +175,7 @@ class Lock(object):
             # there's no value at all, and we have to create it synchronously
             log.debug(
                 "Calling creation function for %s value",
-                "not-yet-present" if not has_value else
-                "previously expired"
+                "not-yet-present" if not has_value else "previously expired",
             )
             return self.creator()
         finally:

--- a/dogpile/util/__init__.py
+++ b/dogpile/util/__init__.py
@@ -1,4 +1,7 @@
+from .langhelpers import coerce_string_conf  # noqa
+from .langhelpers import KeyReentrantMutex  # noqa
+from .langhelpers import memoized_property  # noqa
+from .langhelpers import PluginLoader  # noqa
+from .langhelpers import to_list  # noqa
 from .nameregistry import NameRegistry  # noqa
 from .readwrite_lock import ReadWriteMutex  # noqa
-from .langhelpers import PluginLoader, memoized_property, \
-    coerce_string_conf, to_list, KeyReentrantMutex  # noqa

--- a/dogpile/util/compat.py
+++ b/dogpile/util/compat.py
@@ -4,8 +4,8 @@ py2k = sys.version_info < (3, 0)
 py3k = sys.version_info >= (3, 0)
 py32 = sys.version_info >= (3, 2)
 py27 = sys.version_info >= (2, 7)
-jython = sys.platform.startswith('java')
-win32 = sys.platform.startswith('win')
+jython = sys.platform.startswith("java")
+win32 = sys.platform.startswith("win")
 
 try:
     import threading
@@ -14,15 +14,16 @@ except ImportError:
 
 
 if py3k:  # pragma: no cover
-    string_types = str,
+    string_types = (str,)
     text_type = str
     string_type = str
 
     if py32:
         callable = callable
     else:
+
         def callable(fn):
-            return hasattr(fn, '__call__')
+            return hasattr(fn, "__call__")
 
     def u(s):
         return s
@@ -34,7 +35,7 @@ if py3k:  # pragma: no cover
     import io
     import _thread as thread
 else:
-    string_types = basestring,
+    string_types = (basestring,)
     text_type = unicode
     string_type = str
 
@@ -45,7 +46,7 @@ else:
         return unicode(s, "unicode_escape")
 
     import ConfigParser as configparser  # noqa
-    import StringIO as io   # noqa
+    import StringIO as io  # noqa
 
     callable = callable  # noqa
     import thread  # noqa
@@ -53,16 +54,17 @@ else:
 
 if py3k:
     import collections
+
     ArgSpec = collections.namedtuple(
-        "ArgSpec",
-        ["args", "varargs", "keywords", "defaults"])
+        "ArgSpec", ["args", "varargs", "keywords", "defaults"]
+    )
 
     from inspect import getfullargspec as inspect_getfullargspec
 
     def inspect_getargspec(func):
-        return ArgSpec(
-            *inspect_getfullargspec(func)[0:4]
-        )
+        return ArgSpec(*inspect_getfullargspec(func)[0:4])
+
+
 else:
     from inspect import getargspec as inspect_getargspec  # noqa
 
@@ -72,9 +74,13 @@ else:
     import cPickle as pickle  # noqa
 
 if py3k:
+
     def read_config_file(config, fileobj):
         return config.read_file(fileobj)
+
+
 else:
+
     def read_config_file(config, fileobj):
         return config.readfp(fileobj)
 
@@ -83,5 +89,6 @@ def timedelta_total_seconds(td):
     if py27:
         return td.total_seconds()
     else:
-        return (td.microseconds + (
-            td.seconds + td.days * 24 * 3600) * 1e6) / 1e6
+        return (
+            td.microseconds + (td.seconds + td.days * 24 * 3600) * 1e6
+        ) / 1e6

--- a/dogpile/util/langhelpers.py
+++ b/dogpile/util/langhelpers.py
@@ -1,5 +1,6 @@
-import re
 import collections
+import re
+
 from . import compat
 
 
@@ -11,13 +12,13 @@ def coerce_string_conf(d):
             continue
 
         v = v.strip()
-        if re.match(r'^[-+]?\d+$', v):
+        if re.match(r"^[-+]?\d+$", v):
             result[k] = int(v)
-        elif re.match(r'^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?$', v):
+        elif re.match(r"^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?$", v):
             result[k] = float(v)
-        elif v.lower() in ('false', 'true'):
-            result[k] = v.lower() == 'true'
-        elif v == 'None':
+        elif v.lower() in ("false", "true"):
+            result[k] = v.lower() == "true"
+        elif v == "None":
             result[k] = None
         else:
             result[k] = v
@@ -34,8 +35,8 @@ class PluginLoader(object):
             return self.impls[name]()
         else:  # pragma NO COVERAGE
             import pkg_resources
-            for impl in pkg_resources.iter_entry_points(
-                    self.group, name):
+
+            for impl in pkg_resources.iter_entry_points(self.group, name):
                 self.impls[name] = impl.load
                 return impl.load()
             else:
@@ -47,6 +48,7 @@ class PluginLoader(object):
         def load():
             mod = __import__(modulepath, fromlist=[objname])
             return getattr(mod, objname)
+
         self.impls[name] = load
 
     class NotFound(Exception):
@@ -55,6 +57,7 @@ class PluginLoader(object):
 
 class memoized_property(object):
     """A read-only @property that is only evaluated once."""
+
     def __init__(self, fget, doc=None):
         self.fget = fget
         self.__doc__ = doc or fget.__doc__
@@ -78,7 +81,6 @@ def to_list(x, default=None):
 
 
 class KeyReentrantMutex(object):
-
     def __init__(self, key, mutex, keys):
         self.key = key
         self.mutex = mutex
@@ -93,13 +95,13 @@ class KeyReentrantMutex(object):
 
         def fac(key):
             return KeyReentrantMutex(key, mutex, keystore)
+
         return fac
 
     def acquire(self, wait=True):
         current_thread = compat.threading.current_thread().ident
         keys = self.keys.get(current_thread)
-        if keys is not None and \
-                self.key not in keys:
+        if keys is not None and self.key not in keys:
             # current lockholder, new key. add it in
             keys.add(self.key)
             return True

--- a/dogpile/util/nameregistry.py
+++ b/dogpile/util/nameregistry.py
@@ -1,5 +1,6 @@
-from .compat import threading
 import weakref
+
+from .compat import threading
 
 
 class NameRegistry(object):
@@ -37,6 +38,7 @@ class NameRegistry(object):
      method.
 
     """
+
     _locks = weakref.WeakValueDictionary()
     _mutex = threading.RLock()
 
@@ -76,11 +78,13 @@ class NameRegistry(object):
                     return self._values[identifier]
                 else:
                     self._values[identifier] = value = self.creator(
-                        identifier, *args, **kw)
+                        identifier, *args, **kw
+                    )
                     return value
             except KeyError:
                 self._values[identifier] = value = self.creator(
-                    identifier, *args, **kw)
+                    identifier, *args, **kw
+                )
                 return value
         finally:
             self._mutex.release()

--- a/dogpile/util/readwrite_lock.py
+++ b/dogpile/util/readwrite_lock.py
@@ -1,6 +1,7 @@
+import logging
+
 from .compat import threading
 
-import logging
 log = logging.getLogger(__name__)
 
 
@@ -67,8 +68,10 @@ class ReadWriteMutex(object):
                 if self.current_sync_operation is not None:
                     self.condition.notifyAll()
             elif self.async_ < 0:
-                raise LockError("Synchronizer error - too many "
-                                "release_read_locks called")
+                raise LockError(
+                    "Synchronizer error - too many "
+                    "release_read_locks called"
+                )
             log.debug("%s released read lock", self)
         finally:
             self.condition.release()
@@ -116,8 +119,10 @@ class ReadWriteMutex(object):
         self.condition.acquire()
         try:
             if self.current_sync_operation is not threading.currentThread():
-                raise LockError("Synchronizer error - current thread doesn't "
-                                "have the write lock")
+                raise LockError(
+                    "Synchronizer error - current thread doesn't "
+                    "have the write lock"
+                )
 
             # reset the current sync operation so
             # another can get it

--- a/hash_port.py
+++ b/hash_port.py
@@ -1,9 +1,10 @@
-"""Helper script which provides an integer
-number from a given range based on a hash of 
-current directory name.   
+"""
+Helper script which provides an integer
+number from a given range based on a hash of
+current directory name.
 
 This is used in continuous integration as a helper
-to provide ports to assign to services like 
+to provide ports to assign to services like
 Redis, Memcached when they are run on a per-test basis.
 
 E.g. in a Jenkins job, one could put as the run command::
@@ -11,13 +12,11 @@ E.g. in a Jenkins job, one could put as the run command::
     export TOX_DOGPILE_PORT=`python hash_port.py 10000 34000`
     tox -r -e ${pyv}-${backend}
 
-So you'd get one TOX_DOGPILE_PORT for the script in 
-/var/lib/jenkins-workspace/py27-redis, another TOX_DOGPILE_PORT 
+So you'd get one TOX_DOGPILE_PORT for the script in
+/var/lib/jenkins-workspace/py27-redis, another TOX_DOGPILE_PORT
 for the script in /var/lib/jenkins-workspace/py34-memcached.
 tox calls the pifpaf tool to run redis/ memcached local to that
 build and has it listen on this port.
-
-
 """
 import os
 import sys
@@ -26,5 +25,4 @@ start, end = int(sys.argv[1]), int(sys.argv[2])
 
 dir_ = os.getcwd()
 
-print (hash(dir_) % (end - start)) + start
-
+print(hash(dir_) % (end - start)) + start

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ sign = 1
 identity = C4DAFEE1
 
 [flake8]
+ignore = W503
 exclude = docs/*
 
 [tool:pytest]
@@ -18,4 +19,3 @@ addopts= --tb native -v -r fxX  -p no:logging
 python_files=tests/*test_*.py
 filterwarnings =
     error
-

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ v = open(
         os.path.dirname(__file__),
         'dogpile', '__init__.py')
 )
-VERSION = re.compile(r".*__version__ = '(.*?)'", re.S).match(v.read()).group(1)
+VERSION = re.compile(r'.*__version__ = "(.*?)"', re.S).match(v.read()).group(1)
 v.close()
 
 readme = os.path.join(os.path.dirname(__file__), 'README.rst')

--- a/tests/cache/__init__.py
+++ b/tests/cache/__init__.py
@@ -1,9 +1,11 @@
-import re
-import pytest
 from functools import wraps
-from dogpile.util import compat
-from dogpile.util.compat import configparser, io  # noqa
+import re
 import time
+
+from dogpile.util import compat
+from dogpile.util.compat import configparser  # noqa
+from dogpile.util.compat import io  # noqa
+import pytest
 
 
 def eq_(a, b, msg=None):
@@ -34,7 +36,7 @@ def winsleep():
     # sufficient for windows time.time()
     # to change
     if compat.win32:
-        time.sleep(.001)
+        time.sleep(0.001)
 
 
 def requires_py3k(fn):
@@ -43,4 +45,5 @@ def requires_py3k(fn):
         if compat.py2k:
             pytest.skip("Python 3 required")
         return fn(*arg, **kw)
+
     return wrap

--- a/tests/cache/_fixtures.py
+++ b/tests/cache/_fixtures.py
@@ -1,23 +1,28 @@
-from dogpile.cache.api import CacheBackend, NO_VALUE
-from dogpile.cache import register_backend, CacheRegion
-from dogpile.cache.region import _backend_loader
-from . import eq_, assert_raises_message
-import itertools
-import time
-import pytest
-from threading import Thread, Lock
-from unittest import TestCase
-import random
 import collections
+import itertools
+import random
+from threading import Lock
+from threading import Thread
+import time
+from unittest import TestCase
+
+from dogpile.cache import CacheRegion
+from dogpile.cache import register_backend
+from dogpile.cache.api import CacheBackend
+from dogpile.cache.api import NO_VALUE
+from dogpile.cache.region import _backend_loader
+import pytest
+
+from . import assert_raises_message
+from . import eq_
 
 
 class _GenericBackendFixture(object):
-
     @classmethod
     def setup_class(cls):
         backend_cls = _backend_loader.load(cls.backend)
         try:
-            arguments = cls.config_args.get('arguments', {})
+            arguments = cls.config_args.get("arguments", {})
             backend = backend_cls(arguments)
         except ImportError:
             pytest.skip("Backend %s not installed" % cls.backend)
@@ -54,6 +59,7 @@ class _GenericBackendFixture(object):
                 key = existing_key_mangler(key)
             self._keys.add(key)
             return key
+
         self._region_inst = reg = CacheRegion(**_region_args)
 
         existing_key_mangler = self._region_inst.key_mangler
@@ -66,13 +72,12 @@ class _GenericBackendFixture(object):
     def _backend(self):
         backend_cls = _backend_loader.load(self.backend)
         _config_args = self.config_args.copy()
-        arguments = _config_args.get('arguments', {})
+        arguments = _config_args.get("arguments", {})
         self._backend_inst = backend_cls(arguments)
         return self._backend_inst
 
 
 class _GenericBackendTest(_GenericBackendFixture, TestCase):
-
     def test_backend_get_nothing(self):
         backend = self._backend()
         eq_(backend.get("some_key"), NO_VALUE)
@@ -99,11 +104,11 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
 
     def test_region_set_multiple_values(self):
         reg = self._region()
-        values = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}
+        values = {"key1": "value1", "key2": "value2", "key3": "value3"}
         reg.set_multi(values)
-        eq_(values['key1'], reg.get('key1'))
-        eq_(values['key2'], reg.get('key2'))
-        eq_(values['key3'], reg.get('key3'))
+        eq_(values["key1"], reg.get("key1"))
+        eq_(values["key2"], reg.get("key2"))
+        eq_(values["key3"], reg.get("key3"))
 
     def test_region_get_zero_multiple_values(self):
         reg = self._region()
@@ -121,35 +126,34 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
     def test_region_get_or_create_multi_w_should_cache_none(self):
         reg = self._region()
         values = reg.get_or_create_multi(
-            ['key1', 'key2', 'key3'], lambda *k: [None, None, None],
-            should_cache_fn=lambda v: v is not None)
+            ["key1", "key2", "key3"],
+            lambda *k: [None, None, None],
+            should_cache_fn=lambda v: v is not None,
+        )
         eq_(values, [None, None, None])
 
     def test_region_get_multiple_values(self):
         reg = self._region()
-        key1 = 'value1'
-        key2 = 'value2'
-        key3 = 'value3'
-        reg.set('key1', key1)
-        reg.set('key2', key2)
-        reg.set('key3', key3)
-        values = reg.get_multi(['key1', 'key2', 'key3'])
-        eq_(
-            [key1, key2, key3], values
-        )
+        key1 = "value1"
+        key2 = "value2"
+        key3 = "value3"
+        reg.set("key1", key1)
+        reg.set("key2", key2)
+        reg.set("key3", key3)
+        values = reg.get_multi(["key1", "key2", "key3"])
+        eq_([key1, key2, key3], values)
 
     def test_region_get_nothing_multiple(self):
         reg = self._region()
-        reg.delete_multi(['key1', 'key2', 'key3', 'key4', 'key5'])
-        values = {'key1': 'value1', 'key3': 'value3', 'key5': 'value5'}
+        reg.delete_multi(["key1", "key2", "key3", "key4", "key5"])
+        values = {"key1": "value1", "key3": "value3", "key5": "value5"}
         reg.set_multi(values)
         reg_values = reg.get_multi(
-            ['key1', 'key2', 'key3', 'key4', 'key5', 'key6'])
+            ["key1", "key2", "key3", "key4", "key5", "key6"]
+        )
         eq_(
             reg_values,
-            ["value1", NO_VALUE, "value3", NO_VALUE,
-                "value5", NO_VALUE
-             ]
+            ["value1", NO_VALUE, "value3", NO_VALUE, "value5", NO_VALUE],
         )
 
     def test_region_get_empty_multiple(self):
@@ -159,13 +163,13 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
 
     def test_region_delete_multiple(self):
         reg = self._region()
-        values = {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}
+        values = {"key1": "value1", "key2": "value2", "key3": "value3"}
         reg.set_multi(values)
-        reg.delete_multi(['key2', 'key10'])
-        eq_(values['key1'], reg.get('key1'))
-        eq_(NO_VALUE, reg.get('key2'))
-        eq_(values['key3'], reg.get('key3'))
-        eq_(NO_VALUE, reg.get('key10'))
+        reg.delete_multi(["key2", "key10"])
+        eq_(values["key1"], reg.get("key1"))
+        eq_(NO_VALUE, reg.get("key2"))
+        eq_(values["key3"], reg.get("key3"))
+        eq_(NO_VALUE, reg.get("key10"))
 
     def test_region_set_get_nothing(self):
         reg = self._region()
@@ -177,20 +181,21 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
 
         def creator():
             return "some value"
+
         eq_(reg.get_or_create("some key", creator), "some value")
 
     def test_threaded_dogpile(self):
         # run a basic dogpile concurrency test.
         # note the concurrency of dogpile itself
         # is intensively tested as part of dogpile.
-        reg = self._region(config_args={"expiration_time": .25})
+        reg = self._region(config_args={"expiration_time": 0.25})
         lock = Lock()
         canary = []
 
         def creator():
             ack = lock.acquire(False)
             canary.append(ack)
-            time.sleep(.25)
+            time.sleep(0.25)
             if ack:
                 lock.release()
             return "some value"
@@ -198,7 +203,7 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
         def f():
             for x in range(5):
                 reg.get_or_create("some key", creator)
-                time.sleep(.5)
+                time.sleep(0.5)
 
         threads = [Thread(target=f) for i in range(10)]
         for t in threads:
@@ -212,7 +217,7 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
             assert False in canary
 
     def test_threaded_get_multi(self):
-        reg = self._region(config_args={"expiration_time": .25})
+        reg = self._region(config_args={"expiration_time": 0.25})
         locks = dict((str(i), Lock()) for i in range(11))
 
         canary = collections.defaultdict(list)
@@ -230,7 +235,7 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
             for acq, key in zip(ack, keys):
                 canary[key].append(acq)
 
-            time.sleep(.5)
+            time.sleep(0.5)
 
             for acq, key in zip(ack, keys):
                 if acq:
@@ -240,10 +245,14 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
         def f():
             for x in range(5):
                 reg.get_or_create_multi(
-                    [str(random.randint(1, 10))
-                        for i in range(random.randint(1, 5))],
-                    creator)
-                time.sleep(.5)
+                    [
+                        str(random.randint(1, 10))
+                        for i in range(random.randint(1, 5))
+                    ],
+                    creator,
+                )
+                time.sleep(0.5)
+
         f()
         return
         threads = [Thread(target=f) for i in range(5)]
@@ -264,13 +273,14 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
         eq_(reg.get("some key"), NO_VALUE)
 
     def test_region_expire(self):
-        reg = self._region(config_args={"expiration_time": .25})
+        reg = self._region(config_args={"expiration_time": 0.25})
         counter = itertools.count(1)
 
         def creator():
             return "some value %d" % next(counter)
+
         eq_(reg.get_or_create("some key", creator), "some value 1")
-        time.sleep(.4)
+        time.sleep(0.4)
         eq_(reg.get("some key", ignore_expiration=True), "some value 1")
         eq_(reg.get_or_create("some key", creator), "some value 2")
         eq_(reg.get("some key"), "some value 2")
@@ -307,14 +317,11 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
             raise Exception("boom")
 
         assert_raises_message(
-            Exception,
-            "boom",
-            reg.get_or_create, "some_key", boom
+            Exception, "boom", reg.get_or_create, "some_key", boom
         )
 
 
 class _GenericMutexTest(_GenericBackendFixture, TestCase):
-
     def test_mutex(self):
         backend = self._backend()
         mutex = backend.get_mutex("foo")
@@ -342,11 +349,11 @@ class _GenericMutexTest(_GenericBackendFixture, TestCase):
                 for y in range(5):
                     ack = lock.acquire(False)
                     canary.append(ack)
-                    time.sleep(.002)
+                    time.sleep(0.002)
                     if ack:
                         lock.release()
                 mutex.release()
-                time.sleep(.02)
+                time.sleep(0.02)
 
         threads = [Thread(target=f) for i in range(5)]
         for t in threads:
@@ -381,18 +388,11 @@ class _GenericMutexTest(_GenericBackendFixture, TestCase):
         def create_bar():
             return "bar"
 
-        eq_(
-            reg.get_or_create("foo", create_foo),
-            "foobar"
-        )
-        eq_(
-            reg.get_or_create("foo", create_foo),
-            "foobar"
-        )
+        eq_(reg.get_or_create("foo", create_foo), "foobar")
+        eq_(reg.get_or_create("foo", create_foo), "foobar")
 
 
 class MockMutex(object):
-
     def __init__(self, key):
         self.key = key
 
@@ -404,7 +404,6 @@ class MockMutex(object):
 
 
 class MockBackend(CacheBackend):
-
     def __init__(self, arguments):
         self.arguments = arguments
         self._cache = {}
@@ -419,9 +418,7 @@ class MockBackend(CacheBackend):
             return NO_VALUE
 
     def get_multi(self, keys):
-        return [
-            self.get(key) for key in keys
-        ]
+        return [self.get(key) for key in keys]
 
     def set(self, key, value):
         self._cache[key] = value
@@ -436,4 +433,6 @@ class MockBackend(CacheBackend):
     def delete_multi(self, keys):
         for key in keys:
             self.delete(key)
+
+
 register_backend("mock", __name__, "MockBackend")

--- a/tests/cache/plugins/test_mako_cache.py
+++ b/tests/cache/plugins/test_mako_cache.py
@@ -1,6 +1,11 @@
-from .. import eq_
 from unittest import TestCase
+
+from mako.cache import register_plugin
+from mako.template import Template
+import mock
 import pytest
+
+from .. import eq_
 
 
 try:
@@ -8,47 +13,41 @@ try:
 except ImportError:
     raise pytest.skip("this test suite requires mako templates")
 
-from mako.template import Template
-from mako.cache import register_plugin
-import mock
-
 register_plugin(
-    "dogpile.cache", "dogpile.cache.plugins.mako_cache", "MakoPlugin")
+    "dogpile.cache", "dogpile.cache.plugins.mako_cache", "MakoPlugin"
+)
 
 
 class TestMakoPlugin(TestCase):
-
     def _mock_fixture(self):
         reg = mock.MagicMock()
         reg.get_or_create.return_value = "hello world"
-        my_regions = {
-            "myregion": reg
-        }
-        return {
-            'cache_impl': 'dogpile.cache',
-            'cache_args': {'regions': my_regions}
-        }, reg
+        my_regions = {"myregion": reg}
+        return (
+            {
+                "cache_impl": "dogpile.cache",
+                "cache_args": {"regions": my_regions},
+            },
+            reg,
+        )
 
     def test_basic(self):
         kw, reg = self._mock_fixture()
-        t = Template(
-            '<%page cached="True" cache_region="myregion"/>hi',
-            **kw
-        )
+        t = Template('<%page cached="True" cache_region="myregion"/>hi', **kw)
         t.render()
         eq_(reg.get_or_create.call_count, 1)
 
     def test_timeout(self):
         kw, reg = self._mock_fixture()
-        t = Template("""
+        t = Template(
+            """
                 <%def name="mydef()" cached="True" cache_region="myregion"
                         cache_timeout="20">
                     some content
                 </%def>
                 ${mydef()}
-                """, **kw)
-        t.render()
-        eq_(
-            reg.get_or_create.call_args[1],
-            {"expiration_time": 20}
+                """,
+            **kw
         )
+        t.render()
+        eq_(reg.get_or_create.call_args[1], {"expiration_time": 20})

--- a/tests/cache/test_dbm_backend.py
+++ b/tests/cache/test_dbm_backend.py
@@ -1,19 +1,22 @@
-from ._fixtures import _GenericBackendTest, _GenericMutexTest
-from . import assert_raises_message
 import os
 import sys
-from dogpile.util.readwrite_lock import ReadWriteMutex
+
 from dogpile.cache.backends.file import AbstractFileLock
+from dogpile.util.readwrite_lock import ReadWriteMutex
+
+from . import assert_raises_message
+from ._fixtures import _GenericBackendTest
+from ._fixtures import _GenericMutexTest
 
 try:
     import fcntl  # noqa
+
     has_fcntl = True
 except ImportError:
     has_fcntl = False
 
 
 class MutexLock(AbstractFileLock):
-
     def __init__(self, filename):
         self.mutex = ReadWriteMutex()
 
@@ -31,27 +34,22 @@ class MutexLock(AbstractFileLock):
     def release_write_lock(self):
         return self.mutex.release_write_lock()
 
+
 test_fname = "test_%s.db" % sys.hexversion
 
 if has_fcntl:
+
     class DBMBackendTest(_GenericBackendTest):
         backend = "dogpile.cache.dbm"
 
-        config_args = {
-            "arguments": {
-                "filename": test_fname
-            }
-        }
+        config_args = {"arguments": {"filename": test_fname}}
 
 
 class DBMBackendConditionTest(_GenericBackendTest):
     backend = "dogpile.cache.dbm"
 
     config_args = {
-        "arguments": {
-            "filename": test_fname,
-            "lock_factory": MutexLock
-        }
+        "arguments": {"filename": test_fname, "lock_factory": MutexLock}
     }
 
 
@@ -74,9 +72,7 @@ class _DBMMutexTest(_GenericMutexTest):
         backend = self._backend()
         m1 = backend.get_mutex("foo")
         assert_raises_message(
-            AssertionError,
-            "this thread didn't do the acquire",
-            m1.release
+            AssertionError, "this thread didn't do the acquire", m1.release
         )
 
     def test_release_assertion_key(self):
@@ -87,28 +83,21 @@ class _DBMMutexTest(_GenericMutexTest):
         m1.acquire()
         try:
             assert_raises_message(
-                AssertionError,
-                "No acquire held for key 'bar'",
-                m2.release
+                AssertionError, "No acquire held for key 'bar'", m2.release
             )
         finally:
             m1.release()
 
+
 if has_fcntl:
+
     class DBMMutexFileTest(_DBMMutexTest):
-        config_args = {
-            "arguments": {
-                "filename": test_fname,
-            }
-        }
+        config_args = {"arguments": {"filename": test_fname}}
 
 
 class DBMMutexConditionTest(_DBMMutexTest):
     config_args = {
-        "arguments": {
-            "filename": test_fname,
-            "lock_factory": MutexLock
-        }
+        "arguments": {"filename": test_fname, "lock_factory": MutexLock}
     }
 
 

--- a/tests/cache/test_decorator.py
+++ b/tests/cache/test_decorator.py
@@ -1,47 +1,57 @@
 #! coding: utf-8
 
-from ._fixtures import _GenericBackendFixture
-from . import eq_, requires_py3k, winsleep
-from unittest import TestCase
-import time
-from dogpile.cache import util
-from dogpile.util import compat
 import itertools
+import time
+from unittest import TestCase
+
+from dogpile.cache import util
 from dogpile.cache.api import NO_VALUE
+from dogpile.util import compat
+
+from . import eq_
+from . import requires_py3k
+from . import winsleep
+from ._fixtures import _GenericBackendFixture
 
 
 class DecoratorTest(_GenericBackendFixture, TestCase):
     backend = "dogpile.cache.memory"
 
-    def _fixture(self, namespace=None, expiration_time=None,
-                 key_generator=None):
-        reg = self._region(config_args={"expiration_time": .25})
+    def _fixture(
+        self, namespace=None, expiration_time=None, key_generator=None
+    ):
+        reg = self._region(config_args={"expiration_time": 0.25})
 
         counter = itertools.count(1)
 
         @reg.cache_on_arguments(
             namespace=namespace,
             expiration_time=expiration_time,
-            function_key_generator=key_generator)
+            function_key_generator=key_generator,
+        )
         def go(a, b):
             val = next(counter)
             return val, a, b
+
         return go
 
-    def _multi_fixture(self, namespace=None, expiration_time=None,
-                       key_generator=None):
+    def _multi_fixture(
+        self, namespace=None, expiration_time=None, key_generator=None
+    ):
 
-        reg = self._region(config_args={"expiration_time": .25})
+        reg = self._region(config_args={"expiration_time": 0.25})
 
         counter = itertools.count(1)
 
         @reg.cache_multi_on_arguments(
             namespace=namespace,
             expiration_time=expiration_time,
-            function_multi_key_generator=key_generator)
+            function_multi_key_generator=key_generator,
+        )
         def go(*args):
             val = next(counter)
             return ["%d %s" % (val, arg) for arg in args]
+
         return go
 
     def test_decorator(self):
@@ -49,7 +59,7 @@ class DecoratorTest(_GenericBackendFixture, TestCase):
         eq_(go(1, 2), (1, 1, 2))
         eq_(go(3, 4), (2, 3, 4))
         eq_(go(1, 2), (1, 1, 2))
-        time.sleep(.3)
+        time.sleep(0.3)
         eq_(go(1, 2), (3, 1, 2))
 
     def test_decorator_namespace(self):
@@ -59,27 +69,27 @@ class DecoratorTest(_GenericBackendFixture, TestCase):
         eq_(go(1, 2), (1, 1, 2))
         eq_(go(3, 4), (2, 3, 4))
         eq_(go(1, 2), (1, 1, 2))
-        time.sleep(.3)
+        time.sleep(0.3)
         eq_(go(1, 2), (3, 1, 2))
 
     def test_decorator_custom_expire(self):
-        go = self._fixture(expiration_time=.5)
+        go = self._fixture(expiration_time=0.5)
         eq_(go(1, 2), (1, 1, 2))
         eq_(go(3, 4), (2, 3, 4))
         eq_(go(1, 2), (1, 1, 2))
-        time.sleep(.3)
+        time.sleep(0.3)
         eq_(go(1, 2), (1, 1, 2))
-        time.sleep(.3)
+        time.sleep(0.3)
         eq_(go(1, 2), (3, 1, 2))
 
     def test_decorator_expire_callable(self):
-        go = self._fixture(expiration_time=lambda: .5)
+        go = self._fixture(expiration_time=lambda: 0.5)
         eq_(go(1, 2), (1, 1, 2))
         eq_(go(3, 4), (2, 3, 4))
         eq_(go(1, 2), (1, 1, 2))
-        time.sleep(.3)
+        time.sleep(0.3)
         eq_(go(1, 2), (1, 1, 2))
-        time.sleep(.3)
+        time.sleep(0.3)
         eq_(go(1, 2), (3, 1, 2))
 
     def test_decorator_expire_callable_zero(self):
@@ -119,18 +129,18 @@ class DecoratorTest(_GenericBackendFixture, TestCase):
 
     def test_explicit_get_multi(self):
         go = self._multi_fixture(expiration_time=1)
-        eq_(go(1, 2), ['1 1', '1 2'])
-        eq_(go.get(1, 2), ['1 1', '1 2'])
-        eq_(go.get(3, 1), [NO_VALUE, '1 1'])
-        eq_(go(3, 1), ['2 3', '1 1'])
-        eq_(go.get(3, 1), ['2 3', '1 1'])
+        eq_(go(1, 2), ["1 1", "1 2"])
+        eq_(go.get(1, 2), ["1 1", "1 2"])
+        eq_(go.get(3, 1), [NO_VALUE, "1 1"])
+        eq_(go(3, 1), ["2 3", "1 1"])
+        eq_(go.get(3, 1), ["2 3", "1 1"])
 
     def test_explicit_set_multi(self):
         go = self._multi_fixture(expiration_time=1)
-        eq_(go(1, 2), ['1 1', '1 2'])
-        eq_(go(1, 2), ['1 1', '1 2'])
-        go.set({1: '1 5', 2: '1 6'})
-        eq_(go(1, 2), ['1 5', '1 6'])
+        eq_(go(1, 2), ["1 1", "1 2"])
+        eq_(go(1, 2), ["1 1", "1 2"])
+        go.set({1: "1 5", 2: "1 6"})
+        eq_(go(1, 2), ["1 5", "1 6"])
 
     def test_explicit_refresh(self):
         go = self._fixture(expiration_time=1)
@@ -143,11 +153,11 @@ class DecoratorTest(_GenericBackendFixture, TestCase):
 
     def test_explicit_refresh_multi(self):
         go = self._multi_fixture(expiration_time=1)
-        eq_(go(1, 2), ['1 1', '1 2'])
-        eq_(go(1, 2), ['1 1', '1 2'])
-        eq_(go.refresh(1, 2), ['2 1', '2 2'])
-        eq_(go(1, 2), ['2 1', '2 2'])
-        eq_(go(1, 2), ['2 1', '2 2'])
+        eq_(go(1, 2), ["1 1", "1 2"])
+        eq_(go(1, 2), ["1 1", "1 2"])
+        eq_(go.refresh(1, 2), ["2 1", "2 2"])
+        eq_(go(1, 2), ["2 1", "2 2"])
+        eq_(go(1, 2), ["2 1", "2 2"])
 
     def test_decorator_key_generator(self):
         def my_key_generator(namespace, fn, **kw):
@@ -155,13 +165,14 @@ class DecoratorTest(_GenericBackendFixture, TestCase):
 
             def generate_key_with_first_argument(*args):
                 return fname + "_" + str(args[0])
+
             return generate_key_with_first_argument
 
         go = self._fixture(key_generator=my_key_generator)
         eq_(go(1, 2), (1, 1, 2))
         eq_(go(3, 4), (2, 3, 4))
         eq_(go(1, 3), (1, 1, 2))
-        time.sleep(.3)
+        time.sleep(0.3)
         eq_(go(1, 3), (3, 1, 3))
 
     def test_decorator_key_generator_multi(self):
@@ -169,25 +180,26 @@ class DecoratorTest(_GenericBackendFixture, TestCase):
             fname = fn.__name__
 
             def generate_key_with_reversed_order(*args):
-                return [fname + '_' + str(a) for a in args][::-1]
+                return [fname + "_" + str(a) for a in args][::-1]
+
             return generate_key_with_reversed_order
 
         go = self._multi_fixture(key_generator=my_key_generator)
-        eq_(go(1, 2), ['1 1', '1 2'])
-        eq_(go.get(1, 2), ['1 1', '1 2'])
-        eq_(go.get(3, 1), ['1 2', NO_VALUE])
-        eq_(go(3, 1), ['1 2', '2 1'])
-        eq_(go.get(3, 1), ['1 2', '2 1'])
+        eq_(go(1, 2), ["1 1", "1 2"])
+        eq_(go.get(1, 2), ["1 1", "1 2"])
+        eq_(go.get(3, 1), ["1 2", NO_VALUE])
+        eq_(go(3, 1), ["1 2", "2 1"])
+        eq_(go.get(3, 1), ["1 2", "2 1"])
 
 
 class KeyGenerationTest(TestCase):
-
     def _keygen_decorator(self, namespace=None, **kw):
         canary = []
 
         def decorate(fn):
             canary.append(util.function_key_generator(namespace, fn, **kw))
             return fn
+
         return decorate, canary
 
     def _multi_keygen_decorator(self, namespace=None, **kw):
@@ -195,8 +207,10 @@ class KeyGenerationTest(TestCase):
 
         def decorate(fn):
             canary.append(
-                util.function_multi_key_generator(namespace, fn, **kw))
+                util.function_multi_key_generator(namespace, fn, **kw)
+            )
             return fn
+
         return decorate, canary
 
     def _kwarg_keygen_decorator(self, namespace=None, **kw):
@@ -204,8 +218,10 @@ class KeyGenerationTest(TestCase):
 
         def decorate(fn):
             canary.append(
-                util.kwarg_function_key_generator(namespace, fn, **kw))
+                util.kwarg_function_key_generator(namespace, fn, **kw)
+            )
             return fn
+
         return decorate, canary
 
     def test_default_keygen_kwargs_raises_value_error(self):
@@ -224,6 +240,7 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
         result_key = "tests.cache.test_decorator:one|1 2"
@@ -239,6 +256,7 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a, b=None):
             pass
+
         gen = canary[0]
 
         result_key = "tests.cache.test_decorator:one|1 2"
@@ -255,6 +273,7 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a=True, b=None):
             pass
+
         gen = canary[0]
 
         result_key = "tests.cache.test_decorator:one|1 2"
@@ -265,8 +284,8 @@ class KeyGenerationTest(TestCase):
         eq_(gen(b=2, a=1), result_key)
         eq_(gen(a=1), "tests.cache.test_decorator:one|1 None")
         eq_(gen(1), "tests.cache.test_decorator:one|1 None")
-        eq_(gen(),  "tests.cache.test_decorator:one|True None")
-        eq_(gen(b=2),  "tests.cache.test_decorator:one|True 2")
+        eq_(gen(), "tests.cache.test_decorator:one|True None")
+        eq_(gen(b=2), "tests.cache.test_decorator:one|True 2")
 
     def test_keygen_fn(self):
         decorate, canary = self._keygen_decorator()
@@ -274,6 +293,7 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
         eq_(gen(1, 2), "tests.cache.test_decorator:one|1 2")
@@ -285,12 +305,16 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
-        eq_(gen(1, 2), [
-            "tests.cache.test_decorator:one|1",
-            "tests.cache.test_decorator:one|2"
-        ])
+        eq_(
+            gen(1, 2),
+            [
+                "tests.cache.test_decorator:one|1",
+                "tests.cache.test_decorator:one|2",
+            ],
+        )
 
     def test_keygen_fn_namespace(self):
         decorate, canary = self._keygen_decorator("mynamespace")
@@ -298,6 +322,7 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
         eq_(gen(1, 2), "tests.cache.test_decorator:one|mynamespace|1 2")
@@ -309,6 +334,7 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
         eq_(gen(1, 2), "tests.cache.test_decorator:one|mynamespace|1 2")
@@ -320,9 +346,10 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
-        assert isinstance(gen('foo'), str)
+        assert isinstance(gen("foo"), str)
 
     def test_kwarg_kwgen_key_isnt_unicode_bydefault(self):
         decorate, canary = self._kwarg_keygen_decorator("mynamespace")
@@ -330,88 +357,109 @@ class KeyGenerationTest(TestCase):
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
-        assert isinstance(gen('foo'), str)
-
+        assert isinstance(gen("foo"), str)
 
     def test_unicode_key(self):
-        decorate, canary = self._keygen_decorator("mynamespace",
-                                                  to_str=compat.text_type)
+        decorate, canary = self._keygen_decorator(
+            "mynamespace", to_str=compat.text_type
+        )
 
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
-        eq_(gen(compat.u('méil'), compat.u('drôle')),
-            compat.ue("tests.cache.test_decorator:"
-                      "one|mynamespace|m\xe9il dr\xf4le"))
+        eq_(
+            gen(compat.u("méil"), compat.u("drôle")),
+            compat.ue(
+                "tests.cache.test_decorator:"
+                "one|mynamespace|m\xe9il dr\xf4le"
+            ),
+        )
 
     def test_unicode_key_kwarg_generator(self):
         decorate, canary = self._kwarg_keygen_decorator(
-            "mynamespace",
-            to_str=compat.text_type)
+            "mynamespace", to_str=compat.text_type
+        )
 
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
-        eq_(gen(compat.u('méil'), compat.u('drôle')),
-            compat.ue("tests.cache.test_decorator:"
-                      "one|mynamespace|m\xe9il dr\xf4le"))
+        eq_(
+            gen(compat.u("méil"), compat.u("drôle")),
+            compat.ue(
+                "tests.cache.test_decorator:"
+                "one|mynamespace|m\xe9il dr\xf4le"
+            ),
+        )
 
     def test_unicode_key_multi(self):
         decorate, canary = self._multi_keygen_decorator(
-            "mynamespace",
-            to_str=compat.text_type)
+            "mynamespace", to_str=compat.text_type
+        )
 
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
-        eq_(gen(compat.u('méil'), compat.u('drôle')),
+        eq_(
+            gen(compat.u("méil"), compat.u("drôle")),
             [
                 compat.ue(
-                    'tests.cache.test_decorator:one|mynamespace|m\xe9il'),
+                    "tests.cache.test_decorator:one|mynamespace|m\xe9il"
+                ),
                 compat.ue(
-                    'tests.cache.test_decorator:one|mynamespace|dr\xf4le')
-        ])
+                    "tests.cache.test_decorator:one|mynamespace|dr\xf4le"
+                ),
+            ],
+        )
 
     @requires_py3k
     def test_unicode_key_by_default(self):
-        decorate, canary = self._keygen_decorator("mynamespace",
-                                                  to_str=compat.text_type)
+        decorate, canary = self._keygen_decorator(
+            "mynamespace", to_str=compat.text_type
+        )
 
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
-        assert isinstance(gen('méil'), str)
+        assert isinstance(gen("méil"), str)
 
-        eq_(gen('méil', 'drôle'),
-            "tests.cache.test_decorator:"
-            "one|mynamespace|m\xe9il dr\xf4le")
+        eq_(
+            gen("méil", "drôle"),
+            "tests.cache.test_decorator:" "one|mynamespace|m\xe9il dr\xf4le",
+        )
 
     @requires_py3k
     def test_unicode_key_by_default_kwarg_generator(self):
         decorate, canary = self._kwarg_keygen_decorator(
-            "mynamespace",
-            to_str=compat.text_type)
+            "mynamespace", to_str=compat.text_type
+        )
 
         @decorate
         def one(a, b):
             pass
+
         gen = canary[0]
 
-        assert isinstance(gen('méil'), str)
+        assert isinstance(gen("méil"), str)
 
-        eq_(gen('méil', 'drôle'),
-            "tests.cache.test_decorator:"
-            "one|mynamespace|m\xe9il dr\xf4le")
+        eq_(
+            gen("méil", "drôle"),
+            "tests.cache.test_decorator:" "one|mynamespace|m\xe9il dr\xf4le",
+        )
 
 
 class CacheDecoratorTest(_GenericBackendFixture, TestCase):
@@ -452,14 +500,12 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         # if these two classes get the same namespace,
         # you get a reentrant deadlock.
         class Foo(object):
-
             @classmethod
             @reg.cache_on_arguments(namespace="foo")
             def generate(cls, x, y):
                 return next(counter) + x + y
 
         class Bar(object):
-
             @classmethod
             @reg.cache_on_arguments(namespace="bar")
             def generate(cls, x, y):
@@ -476,14 +522,14 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         def generate(*args):
             return ["%d %d" % (arg, next(counter)) for arg in args]
 
-        eq_(generate(2, 8, 10), ['2 2', '8 3', '10 1'])
-        eq_(generate(2, 9, 10), ['2 2', '9 4', '10 1'])
+        eq_(generate(2, 8, 10), ["2 2", "8 3", "10 1"])
+        eq_(generate(2, 9, 10), ["2 2", "9 4", "10 1"])
 
         generate.invalidate(2)
-        eq_(generate(2, 7, 10), ['2 5', '7 6', '10 1'])
+        eq_(generate(2, 7, 10), ["2 5", "7 6", "10 1"])
 
         generate.set({7: 18, 10: 15})
-        eq_(generate(2, 7, 10), ['2 5', 18, 15])
+        eq_(generate(2, 7, 10), ["2 5", 18, 15])
 
     def test_multi_asdict(self):
         reg = self._region()
@@ -496,20 +542,17 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
                 [(arg, "%d %d" % (arg, next(counter))) for arg in args]
             )
 
-        eq_(generate(2, 8, 10), {2: '2 2', 8: '8 3', 10: '10 1'})
-        eq_(generate(2, 9, 10), {2: '2 2', 9: '9 4', 10: '10 1'})
+        eq_(generate(2, 8, 10), {2: "2 2", 8: "8 3", 10: "10 1"})
+        eq_(generate(2, 9, 10), {2: "2 2", 9: "9 4", 10: "10 1"})
 
         generate.invalidate(2)
-        eq_(generate(2, 7, 10), {2: '2 5', 7: '7 6', 10: '10 1'})
+        eq_(generate(2, 7, 10), {2: "2 5", 7: "7 6", 10: "10 1"})
 
         generate.set({7: 18, 10: 15})
-        eq_(generate(2, 7, 10), {2: '2 5', 7: 18, 10: 15})
+        eq_(generate(2, 7, 10), {2: "2 5", 7: 18, 10: 15})
 
-        eq_(
-            generate.refresh(2, 7),
-            {2: '2 7', 7: '7 8'}
-        )
-        eq_(generate(2, 7, 10), {2: '2 7', 10: 15, 7: '7 8'})
+        eq_(generate.refresh(2, 7), {2: "2 7", 7: "7 8"})
+        eq_(generate(2, 7, 10), {2: "2 7", 10: 15, 7: "7 8"})
 
     def test_multi_asdict_keys_missing(self):
         reg = self._region()
@@ -519,20 +562,23 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         @reg.cache_multi_on_arguments(asdict=True)
         def generate(*args):
             return dict(
-                [(arg, "%d %d" % (arg, next(counter)))
-                 for arg in args if arg != 10]
+                [
+                    (arg, "%d %d" % (arg, next(counter)))
+                    for arg in args
+                    if arg != 10
+                ]
             )
 
-        eq_(generate(2, 8, 10), {2: '2 1', 8: '8 2'})
-        eq_(generate(2, 9, 10), {2: '2 1', 9: '9 3'})
+        eq_(generate(2, 8, 10), {2: "2 1", 8: "8 2"})
+        eq_(generate(2, 9, 10), {2: "2 1", 9: "9 3"})
 
         assert reg.get(10) is NO_VALUE
 
         generate.invalidate(2)
-        eq_(generate(2, 7, 10), {2: '2 4', 7: '7 5'})
+        eq_(generate(2, 7, 10), {2: "2 4", 7: "7 5"})
 
         generate.set({7: 18, 10: 15})
-        eq_(generate(2, 7, 10), {2: '2 4', 7: 18, 10: 15})
+        eq_(generate(2, 7, 10), {2: "2 4", 7: 18, 10: 15})
 
     def test_multi_asdict_keys_missing_existing_cache_fn(self):
         reg = self._region()
@@ -540,26 +586,29 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         counter = itertools.count(1)
 
         @reg.cache_multi_on_arguments(
-            asdict=True,
-            should_cache_fn=lambda v: not v.startswith('8 '))
+            asdict=True, should_cache_fn=lambda v: not v.startswith("8 ")
+        )
         def generate(*args):
             return dict(
-                [(arg, "%d %d" % (arg, next(counter)))
-                 for arg in args if arg != 10]
+                [
+                    (arg, "%d %d" % (arg, next(counter)))
+                    for arg in args
+                    if arg != 10
+                ]
             )
 
-        eq_(generate(2, 8, 10), {2: '2 1', 8: '8 2'})
-        eq_(generate(2, 8, 10), {2: '2 1', 8: '8 3'})
-        eq_(generate(2, 8, 10), {2: '2 1', 8: '8 4'})
-        eq_(generate(2, 9, 10), {2: '2 1', 9: '9 5'})
+        eq_(generate(2, 8, 10), {2: "2 1", 8: "8 2"})
+        eq_(generate(2, 8, 10), {2: "2 1", 8: "8 3"})
+        eq_(generate(2, 8, 10), {2: "2 1", 8: "8 4"})
+        eq_(generate(2, 9, 10), {2: "2 1", 9: "9 5"})
 
         assert reg.get(10) is NO_VALUE
 
         generate.invalidate(2)
-        eq_(generate(2, 7, 10), {2: '2 6', 7: '7 7'})
+        eq_(generate(2, 7, 10), {2: "2 6", 7: "7 7"})
 
         generate.set({7: 18, 10: 15})
-        eq_(generate(2, 7, 10), {2: '2 6', 7: 18, 10: 15})
+        eq_(generate(2, 7, 10), {2: "2 6", 7: 18, 10: 15})
 
     def test_multi_namespace(self):
         reg = self._region()
@@ -570,22 +619,23 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         def generate(*args):
             return ["%d %d" % (arg, next(counter)) for arg in args]
 
-        eq_(generate(2, 8, 10), ['2 2', '8 3', '10 1'])
-        eq_(generate(2, 9, 10), ['2 2', '9 4', '10 1'])
+        eq_(generate(2, 8, 10), ["2 2", "8 3", "10 1"])
+        eq_(generate(2, 9, 10), ["2 2", "9 4", "10 1"])
 
         eq_(
             sorted(list(reg.backend._cache)),
             [
-                'tests.cache.test_decorator:generate|foo|10',
-                'tests.cache.test_decorator:generate|foo|2',
-                'tests.cache.test_decorator:generate|foo|8',
-                'tests.cache.test_decorator:generate|foo|9']
+                "tests.cache.test_decorator:generate|foo|10",
+                "tests.cache.test_decorator:generate|foo|2",
+                "tests.cache.test_decorator:generate|foo|8",
+                "tests.cache.test_decorator:generate|foo|9",
+            ],
         )
         generate.invalidate(2)
-        eq_(generate(2, 7, 10), ['2 5', '7 6', '10 1'])
+        eq_(generate(2, 7, 10), ["2 5", "7 6", "10 1"])
 
         generate.set({7: 18, 10: 15})
-        eq_(generate(2, 7, 10), ['2 5', 18, 15])
+        eq_(generate(2, 7, 10), ["2 5", 18, 15])
 
     def test_cache_preserve_sig(self):
         reg = self._region()

--- a/tests/cache/test_mako.py
+++ b/tests/cache/test_mako.py
@@ -12,5 +12,6 @@ class MakoTest(TestCase):
         # if the entrypoint isn't there, just pass, as the tests can be run
         # without any setuptools install
         for impl in pkg_resources.iter_entry_points(
-                "mako.cache", "dogpile.cache"):
+            "mako.cache", "dogpile.cache"
+        ):
             impl.load()

--- a/tests/cache/test_memcached_backend.py
+++ b/tests/cache/test_memcached_backend.py
@@ -1,53 +1,52 @@
-from ._fixtures import _GenericBackendTest, _GenericMutexTest
-from . import eq_
-from unittest import TestCase
+import os
 from threading import Thread
 import time
-import pytest
-from dogpile.util import compat
-import os
+from unittest import TestCase
 import weakref
 
+from dogpile.cache.backends.memcached import GenericMemcachedBackend
+from dogpile.cache.backends.memcached import MemcachedBackend
+from dogpile.cache.backends.memcached import PylibmcBackend
+import pytest
 
-MEMCACHED_PORT = os.getenv('DOGPILE_MEMCACHED_PORT', '11211')
+from . import eq_
+from ._fixtures import _GenericBackendTest
+from ._fixtures import _GenericMutexTest
+
+
+MEMCACHED_PORT = os.getenv("DOGPILE_MEMCACHED_PORT", "11211")
 MEMCACHED_URL = "127.0.0.1:%s" % MEMCACHED_PORT
-expect_memcached_running = bool(os.getenv('DOGPILE_MEMCACHED_PORT'))
+expect_memcached_running = bool(os.getenv("DOGPILE_MEMCACHED_PORT"))
 
 LOCK_TIMEOUT = 1
 
 
 class _TestMemcachedConn(object):
-
     @classmethod
     def _check_backend_available(cls, backend):
         try:
             client = backend._create_client()
             client.set("x", "y")
             assert client.get("x") == "y"
-        except:
+        except Exception:
             if not expect_memcached_running:
                 pytest.skip(
                     "memcached is not running or "
-                    "otherwise not functioning correctly")
+                    "otherwise not functioning correctly"
+                )
             else:
                 raise
 
 
 class _NonDistributedMemcachedTest(_TestMemcachedConn, _GenericBackendTest):
-    region_args = {
-        "key_mangler": lambda x: x.replace(" ", "_")
-    }
-    config_args = {
-        "arguments": {
-            "url": MEMCACHED_URL
-        }
-    }
+    region_args = {"key_mangler": lambda x: x.replace(" ", "_")}
+    config_args = {"arguments": {"url": MEMCACHED_URL}}
 
 
-class _DistributedMemcachedWithTimeoutTest(_TestMemcachedConn, _GenericBackendTest):
-    region_args = {
-        "key_mangler": lambda x: x.replace(" ", "_")
-    }
+class _DistributedMemcachedWithTimeoutTest(
+    _TestMemcachedConn, _GenericBackendTest
+):
+    region_args = {"key_mangler": lambda x: x.replace(" ", "_")}
     config_args = {
         "arguments": {
             "url": MEMCACHED_URL,
@@ -58,27 +57,21 @@ class _DistributedMemcachedWithTimeoutTest(_TestMemcachedConn, _GenericBackendTe
 
 
 class _DistributedMemcachedTest(_TestMemcachedConn, _GenericBackendTest):
-    region_args = {
-        "key_mangler": lambda x: x.replace(" ", "_")
-    }
+    region_args = {"key_mangler": lambda x: x.replace(" ", "_")}
     config_args = {
-        "arguments": {
-            "url": MEMCACHED_URL,
-            "distributed_lock": True,
-        }
+        "arguments": {"url": MEMCACHED_URL, "distributed_lock": True}
     }
 
 
 class _DistributedMemcachedMutexTest(_TestMemcachedConn, _GenericMutexTest):
     config_args = {
-        "arguments": {
-            "url": MEMCACHED_URL,
-            "distributed_lock": True
-        }
+        "arguments": {"url": MEMCACHED_URL, "distributed_lock": True}
     }
 
 
-class _DistributedMemcachedMutexWithTimeoutTest(_TestMemcachedConn, _GenericMutexTest):
+class _DistributedMemcachedMutexWithTimeoutTest(
+    _TestMemcachedConn, _GenericMutexTest
+):
     config_args = {
         "arguments": {
             "url": MEMCACHED_URL,
@@ -119,22 +112,24 @@ class BMemcachedTest(BMemcachedSkips, _NonDistributedMemcachedTest):
 
 
 class BMemcachedDistributedWithTimeoutTest(
-        BMemcachedSkips, _DistributedMemcachedWithTimeoutTest):
+    BMemcachedSkips, _DistributedMemcachedWithTimeoutTest
+):
     backend = "dogpile.cache.bmemcached"
 
 
-class BMemcachedDistributedTest(
-        BMemcachedSkips, _DistributedMemcachedTest):
+class BMemcachedDistributedTest(BMemcachedSkips, _DistributedMemcachedTest):
     backend = "dogpile.cache.bmemcached"
 
 
 class BMemcachedDistributedMutexTest(
-        BMemcachedSkips, _DistributedMemcachedMutexTest):
+    BMemcachedSkips, _DistributedMemcachedMutexTest
+):
     backend = "dogpile.cache.bmemcached"
 
 
 class BMemcachedDistributedMutexWithTimeoutTest(
-        BMemcachedSkips, _DistributedMemcachedMutexWithTimeoutTest):
+    BMemcachedSkips, _DistributedMemcachedMutexWithTimeoutTest
+):
     backend = "dogpile.cache.bmemcached"
 
 
@@ -150,13 +145,7 @@ class MemcachedDistributedMutexTest(_DistributedMemcachedMutexTest):
     backend = "dogpile.cache.memcached"
 
 
-from dogpile.cache.backends.memcached import GenericMemcachedBackend
-from dogpile.cache.backends.memcached import PylibmcBackend
-from dogpile.cache.backends.memcached import MemcachedBackend
-
-
 class MockGenericMemcachedBackend(GenericMemcachedBackend):
-
     def _imports(self):
         pass
 
@@ -165,7 +154,6 @@ class MockGenericMemcachedBackend(GenericMemcachedBackend):
 
 
 class MockMemcacheBackend(MemcachedBackend):
-
     def _imports(self):
         pass
 
@@ -174,15 +162,13 @@ class MockMemcacheBackend(MemcachedBackend):
 
 
 class MockPylibmcBackend(PylibmcBackend):
-
     def _imports(self):
         pass
 
     def _create_client(self):
-        return MockClient(self.url,
-                          binary=self.binary,
-                          behaviors=self.behaviors
-                          )
+        return MockClient(
+            self.url, binary=self.binary, behaviors=self.behaviors
+        )
 
 
 class MockClient(object):
@@ -215,61 +201,64 @@ class MockClient(object):
 
 
 class PylibmcArgsTest(TestCase):
-
     def test_binary_flag(self):
-        backend = MockPylibmcBackend(arguments={'url': 'foo', 'binary': True})
+        backend = MockPylibmcBackend(arguments={"url": "foo", "binary": True})
         eq_(backend._create_client().kw["binary"], True)
 
     def test_url_list(self):
-        backend = MockPylibmcBackend(arguments={'url': ["a", "b", "c"]})
+        backend = MockPylibmcBackend(arguments={"url": ["a", "b", "c"]})
         eq_(backend._create_client().arg[0], ["a", "b", "c"])
 
     def test_url_scalar(self):
-        backend = MockPylibmcBackend(arguments={'url': "foo"})
+        backend = MockPylibmcBackend(arguments={"url": "foo"})
         eq_(backend._create_client().arg[0], ["foo"])
 
     def test_behaviors(self):
-        backend = MockPylibmcBackend(arguments={'url': "foo",
-                                                "behaviors": {"q": "p"}})
+        backend = MockPylibmcBackend(
+            arguments={"url": "foo", "behaviors": {"q": "p"}}
+        )
         eq_(backend._create_client().kw["behaviors"], {"q": "p"})
 
     def test_set_time(self):
-        backend = MockPylibmcBackend(arguments={'url': "foo",
-                                                "memcached_expire_time": 20})
+        backend = MockPylibmcBackend(
+            arguments={"url": "foo", "memcached_expire_time": 20}
+        )
         backend.set("foo", "bar")
         eq_(backend._clients.memcached.canary, [{"time": 20}])
 
     def test_set_min_compress_len(self):
-        backend = MockPylibmcBackend(arguments={'url': "foo",
-                                                "min_compress_len": 20})
+        backend = MockPylibmcBackend(
+            arguments={"url": "foo", "min_compress_len": 20}
+        )
         backend.set("foo", "bar")
         eq_(backend._clients.memcached.canary, [{"min_compress_len": 20}])
 
     def test_no_set_args(self):
-        backend = MockPylibmcBackend(arguments={'url': "foo"})
+        backend = MockPylibmcBackend(arguments={"url": "foo"})
         backend.set("foo", "bar")
         eq_(backend._clients.memcached.canary, [{}])
 
 
 class MemcachedArgstest(TestCase):
-
     def test_set_time(self):
-        backend = MockMemcacheBackend(arguments={'url': "foo",
-                                                 "memcached_expire_time": 20})
+        backend = MockMemcacheBackend(
+            arguments={"url": "foo", "memcached_expire_time": 20}
+        )
         backend.set("foo", "bar")
         eq_(backend._clients.memcached.canary, [{"time": 20}])
 
     def test_set_min_compress_len(self):
-        backend = MockMemcacheBackend(arguments={'url': "foo",
-                                                 "min_compress_len": 20})
+        backend = MockMemcacheBackend(
+            arguments={"url": "foo", "min_compress_len": 20}
+        )
         backend.set("foo", "bar")
         eq_(backend._clients.memcached.canary, [{"min_compress_len": 20}])
 
 
 class LocalThreadTest(TestCase):
-
     def setUp(self):
         import gc
+
         gc.collect()
         eq_(MockClient.number_of_clients(), 0)
 
@@ -283,7 +272,7 @@ class LocalThreadTest(TestCase):
         self._test_client_cleanup(10)
 
     def _test_client_cleanup(self, count):
-        backend = MockGenericMemcachedBackend(arguments={'url': 'foo'})
+        backend = MockGenericMemcachedBackend(arguments={"url": "foo"})
         canary = []
 
         flag = [False]
@@ -292,9 +281,9 @@ class LocalThreadTest(TestCase):
             backend._clients.memcached
             canary.append(MockClient.number_of_clients())
             while not flag[0]:
-                time.sleep(.02)
+                time.sleep(0.02)
 
-        threads = [Thread(target=f, args=(count - i, )) for i in range(count)]
+        threads = [Thread(target=f, args=(count - i,)) for i in range(count)]
         for t in threads:
             t.start()
         flag[0] = True
@@ -303,5 +292,6 @@ class LocalThreadTest(TestCase):
         eq_(canary, [i + 1 for i in range(count)])
 
         import gc
+
         gc.collect()
         eq_(MockClient.number_of_clients(), 0)

--- a/tests/cache/test_null_backend.py
+++ b/tests/cache/test_null_backend.py
@@ -1,8 +1,10 @@
-from unittest import TestCase
-from ._fixtures import _GenericBackendFixture
-from dogpile.cache.api import NO_VALUE
-from . import eq_
 import itertools
+from unittest import TestCase
+
+from dogpile.cache.api import NO_VALUE
+
+from . import eq_
+from ._fixtures import _GenericBackendFixture
 
 
 class NullBackendTest(_GenericBackendFixture, TestCase):
@@ -26,32 +28,17 @@ class NullBackendTest(_GenericBackendFixture, TestCase):
     def test_get_multi(self):
         reg = self._region()
 
-        eq_(
-            reg.get_multi(['a', 'b', 'c']),
-            [NO_VALUE, NO_VALUE, NO_VALUE]
-        )
+        eq_(reg.get_multi(["a", "b", "c"]), [NO_VALUE, NO_VALUE, NO_VALUE])
 
     def test_set_multi(self):
         reg = self._region()
-        reg.set_multi(
-            {
-                "a": 1,
-                "b": 2,
-                "c": 3
-            }
-        )
-        eq_(
-            reg.get_multi(['a', 'b', 'c']),
-            [NO_VALUE, NO_VALUE, NO_VALUE]
-        )
+        reg.set_multi({"a": 1, "b": 2, "c": 3})
+        eq_(reg.get_multi(["a", "b", "c"]), [NO_VALUE, NO_VALUE, NO_VALUE])
 
     def test_delete_multi(self):
         reg = self._region()
         reg.delete_multi(["a", "b", "c"])
-        eq_(
-            reg.get_multi(['a', 'b', 'c']),
-            [NO_VALUE, NO_VALUE, NO_VALUE]
-        )
+        eq_(reg.get_multi(["a", "b", "c"]), [NO_VALUE, NO_VALUE, NO_VALUE])
 
     def test_decorator(self):
         reg = self._region()

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -1,17 +1,20 @@
-from dogpile.cache.region import _backend_loader
-from ._fixtures import _GenericBackendTest, _GenericMutexTest
-from unittest import TestCase
-from mock import patch, Mock
-import pytest
 import os
+from unittest import TestCase
 
-REDIS_HOST = '127.0.0.1'
-REDIS_PORT = int(os.getenv('DOGPILE_REDIS_PORT', '6379'))
-expect_redis_running = os.getenv('DOGPILE_REDIS_PORT') is not None
+from dogpile.cache.region import _backend_loader
+from mock import Mock
+from mock import patch
+import pytest
+
+from ._fixtures import _GenericBackendTest
+from ._fixtures import _GenericMutexTest
+
+REDIS_HOST = "127.0.0.1"
+REDIS_PORT = int(os.getenv("DOGPILE_REDIS_PORT", "6379"))
+expect_redis_running = os.getenv("DOGPILE_REDIS_PORT") is not None
 
 
 class _TestRedisConn(object):
-
     @classmethod
     def _check_backend_available(cls, backend):
         try:
@@ -20,42 +23,43 @@ class _TestRedisConn(object):
             # on py3k it appears to return b"y"
             assert client.get("x").decode("ascii") == "y"
             client.delete("x")
-        except:
+        except Exception:
             if not expect_redis_running:
                 pytest.skip(
                     "redis is not running or "
-                    "otherwise not functioning correctly")
+                    "otherwise not functioning correctly"
+                )
             else:
                 raise
 
 
 class RedisTest(_TestRedisConn, _GenericBackendTest):
-    backend = 'dogpile.cache.redis'
+    backend = "dogpile.cache.redis"
     config_args = {
         "arguments": {
-            'host': REDIS_HOST,
-            'port': REDIS_PORT,
-            'db': 0,
-            "foo": "barf"
+            "host": REDIS_HOST,
+            "port": REDIS_PORT,
+            "db": 0,
+            "foo": "barf",
         }
     }
 
 
 class RedisDistributedMutexTest(_TestRedisConn, _GenericMutexTest):
-    backend = 'dogpile.cache.redis'
+    backend = "dogpile.cache.redis"
     config_args = {
         "arguments": {
-            'host': REDIS_HOST,
-            'port': REDIS_PORT,
-            'db': 0,
-            'distributed_lock': True,
+            "host": REDIS_HOST,
+            "port": REDIS_PORT,
+            "db": 0,
+            "distributed_lock": True,
         }
     }
 
 
-@patch('redis.StrictRedis', autospec=True)
+@patch("redis.StrictRedis", autospec=True)
 class RedisConnectionTest(TestCase):
-    backend = 'dogpile.cache.redis'
+    backend = "dogpile.cache.redis"
 
     @classmethod
     def setup_class(cls):
@@ -75,53 +79,49 @@ class RedisConnectionTest(TestCase):
     def test_connect_with_defaults(self, MockStrictRedis):
         # The defaults, used if keys are missing from the arguments dict.
         arguments = {
-            'host': 'localhost',
-            'password': None,
-            'port': 6379,
-            'db': 0,
+            "host": "localhost",
+            "password": None,
+            "port": 6379,
+            "db": 0,
         }
         self._test_helper(MockStrictRedis, arguments, {})
 
     def test_connect_with_basics(self, MockStrictRedis):
         arguments = {
-            'host': '127.0.0.1',
-            'password': None,
-            'port': 6379,
-            'db': 0,
+            "host": "127.0.0.1",
+            "password": None,
+            "port": 6379,
+            "db": 0,
         }
         self._test_helper(MockStrictRedis, arguments)
 
     def test_connect_with_password(self, MockStrictRedis):
         arguments = {
-            'host': '127.0.0.1',
-            'password': 'some password',
-            'port': 6379,
-            'db': 0,
+            "host": "127.0.0.1",
+            "password": "some password",
+            "port": 6379,
+            "db": 0,
         }
         self._test_helper(MockStrictRedis, arguments)
 
     def test_connect_with_socket_timeout(self, MockStrictRedis):
         arguments = {
-            'host': '127.0.0.1',
-            'port': 6379,
-            'socket_timeout': 0.5,
-            'password': None,
-            'db': 0,
+            "host": "127.0.0.1",
+            "port": 6379,
+            "socket_timeout": 0.5,
+            "password": None,
+            "db": 0,
         }
         self._test_helper(MockStrictRedis, arguments)
 
     def test_connect_with_connection_pool(self, MockStrictRedis):
         pool = Mock()
-        arguments = {
-            'connection_pool': pool,
-            'socket_timeout': 0.5
-        }
-        expected_args = {'connection_pool': pool}
-        self._test_helper(MockStrictRedis, expected_args,
-                          connection_args=arguments)
+        arguments = {"connection_pool": pool, "socket_timeout": 0.5}
+        expected_args = {"connection_pool": pool}
+        self._test_helper(
+            MockStrictRedis, expected_args, connection_args=arguments
+        )
 
     def test_connect_with_url(self, MockStrictRedis):
-        arguments = {
-            'url': 'redis://redis:password@127.0.0.1:6379/0'
-        }
+        arguments = {"url": "redis://redis:password@127.0.0.1:6379/0"}
         self._test_helper(MockStrictRedis.from_url, arguments)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
-from _pytest.unittest import UnitTestCase
-import sys
 import logging
-
 import logging.config
+import sys
+
+from _pytest.unittest import UnitTestCase
+
 logging.config.fileConfig("log_tests.ini")
 
 
@@ -12,14 +13,14 @@ def is_unittest(obj):
     Lifted from older versions of py.test, as this seems to be removed.
 
     """
-    unittest = sys.modules.get('unittest')
+    unittest = sys.modules.get("unittest")
     if unittest is None:
         return  # nobody can have derived unittest.TestCase
     try:
         return issubclass(obj, unittest.TestCase)
     except KeyboardInterrupt:
         raise
-    except:
+    except Exception:
         return False
 
 

--- a/tests/test_backgrounding.py
+++ b/tests/test_backgrounding.py
@@ -1,5 +1,6 @@
-import unittest
 import threading
+import unittest
+
 import dogpile
 
 
@@ -12,14 +13,13 @@ class TestAsyncRunner(unittest.TestCase):
             mutex.release()
 
         mutex = threading.Lock()
-        create = lambda: ("value", 1)
-        get = lambda: ("value", 1)
+        create = lambda: ("value", 1)  # noqa
+        get = lambda: ("value", 1)  # noqa
         expiretime = 1
 
         assert not self.called
 
-        with dogpile.Lock(mutex, create, get, expiretime, runner) as l:
+        with dogpile.Lock(mutex, create, get, expiretime, runner) as _:
             assert self.called
 
         assert self.called
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,19 +9,19 @@ class UtilsTest(TestCase):
     """
 
     def test_coerce_string_conf(self):
-        settings = {'expiration_time': '-1'}
+        settings = {"expiration_time": "-1"}
         coerced = util.coerce_string_conf(settings)
-        self.assertEqual(coerced['expiration_time'], -1)
+        self.assertEqual(coerced["expiration_time"], -1)
 
-        settings = {'expiration_time': '+1'}
+        settings = {"expiration_time": "+1"}
         coerced = util.coerce_string_conf(settings)
-        self.assertEqual(coerced['expiration_time'], 1)
-        self.assertEqual(type(coerced['expiration_time']), int)
+        self.assertEqual(coerced["expiration_time"], 1)
+        self.assertEqual(type(coerced["expiration_time"]), int)
 
-        settings = {'arguments.lock_sleep': '0.1'}
+        settings = {"arguments.lock_sleep": "0.1"}
         coerced = util.coerce_string_conf(settings)
-        self.assertEqual(coerced['arguments.lock_sleep'], 0.1)
+        self.assertEqual(coerced["arguments.lock_sleep"], 0.1)
 
-        settings = {'arguments.lock_sleep': '-3.14e-10'}
+        settings = {"arguments.lock_sleep": "-3.14e-10"}
         coerced = util.coerce_string_conf(settings)
-        self.assertEqual(coerced['arguments.lock_sleep'], -3.14e-10)
+        self.assertEqual(coerced["arguments.lock_sleep"], -3.14e-10)

--- a/tests/util/test_nameregistry.py
+++ b/tests/util/test_nameregistry.py
@@ -1,15 +1,15 @@
-from unittest import TestCase
-import time
-import threading
-from dogpile.util import NameRegistry
-import random
-
 import logging
+import random
+import threading
+import time
+from unittest import TestCase
+
+from dogpile.util import NameRegistry
+
 log = logging.getLogger(__name__)
 
 
 class NameRegistryTest(TestCase):
-
     def test_name_registry(self):
         success = [True]
         num_operations = [0]
@@ -20,11 +20,7 @@ class NameRegistryTest(TestCase):
 
         registry = NameRegistry(create)
 
-        baton = {
-            "beans":False,
-            "means":False,
-            "please":False
-        }
+        baton = {"beans": False, "means": False, "please": False}
 
         def do_something(name):
             for iteration in range(20):
@@ -38,7 +34,7 @@ class NameRegistryTest(TestCase):
                         break
                     baton[name] = True
                     try:
-                        time.sleep(random.random() * .01)
+                        time.sleep(random.random() * 0.01)
                     finally:
                         num_operations[0] += 1
                         baton[name] = False
@@ -56,4 +52,3 @@ class NameRegistryTest(TestCase):
             t.join()
 
         assert success[0]
-

--- a/tox.ini
+++ b/tox.ini
@@ -50,10 +50,7 @@ commands = python -m flake8 {posargs}
 
 
 [flake8]
-
 show-source = True
-ignore = E711,E712,E721,D,N
+ignore = E711,E712,E721,D,N,W503
 # F841,F811,F401
 exclude=.venv,.git,.tox,dist,doc,*egg,build
-
-


### PR DESCRIPTION
These changes format code by using:
```
$ black -l79
$ zimports
```

and some manual changes to format the code as PEP8 compliance

Note:
`zimports` introduce some errors on `dogpile/cache/region.py` and `dogpile/util/__init__.py` I suppose import order need to be keeped or something like that.