### PR TITLE
[WIP] Introduce signature utilities for python 3.8

### DIFF
--- a/dogpile/util/compat.py
+++ b/dogpile/util/compat.py
@@ -3,6 +3,7 @@ import sys
 py2k = sys.version_info < (3, 0)
 py3k = sys.version_info >= (3, 0)
 py32 = sys.version_info >= (3, 2)
+py38 = sys.version_info >= (3, 8)
 py27 = sys.version_info >= (2, 7)
 jython = sys.platform.startswith("java")
 win32 = sys.platform.startswith("win")
@@ -61,10 +62,56 @@ if py3k:
         "ArgSpec", ["args", "varargs", "keywords", "defaults"]
     )
 
-    from inspect import getfullargspec as inspect_getfullargspec
+    if py38:
+        from inspect import signature
 
-    def inspect_getargspec(func):
-        return ArgSpec(*inspect_getfullargspec(func)[0:4])
+        def inspect_getargspec(func):
+            sig = signature(func)
+            args = []
+            varargs = None
+            varkw = None
+            kwonlyargs = []
+            defaults = ()
+            annotations = {}
+            defaults = ()
+            kwdefaults = {}
+            for param in sig.parameters.values():
+                kind = param.kind
+                name = param.name
+
+                if kind is param.POSITIONAL_ONLY:
+                    args.append(name)
+                elif kind is param.POSITIONAL_OR_KEYWORD:
+                    args.append(name)
+                    if param.default is not param.empty:
+                        defaults += (param.default,)
+                elif kind is param.VAR_POSITIONAL:
+                    varargs = name
+                elif kind is param.KEYWORD_ONLY:
+                    kwonlyargs.append(name)
+                    if param.default is not param.empty:
+                        kwdefaults[name] = param.default
+                elif kind is param.VAR_KEYWORD:
+                    varkw = name
+
+                if param.annotation is not param.empty:
+                    annotations[name] = param.annotation
+
+            if not kwdefaults:
+                # compatibility with 'func.__kwdefaults__'
+                kwdefaults = None
+
+            if not defaults:
+                # compatibility with 'func.__defaults__'
+                defaults = None
+
+            return ArgSpec(args, varargs, varkw, defaults)
+
+    else:
+        from inspect import getfullargspec as inspect_getfullargspec
+
+        def inspect_getargspec(func):
+            return ArgSpec(*inspect_getfullargspec(func)[0:4])
 
 
 else:


### PR DESCRIPTION
To prevent stdlib getfullargspec deprecation these propose to introduce
a backward compat for python version who will remove getfullargspec.

These changes are more to discuss with you about the cross vendoring between `mako`, `dogpile` etc...

related to #154 