### PR TITLE
add decorator module to testing requirements

### DIFF
--- a/docs/build/changelog.rst
+++ b/docs/build/changelog.rst
@@ -6,6 +6,13 @@ Changelog
     :version: 0.9.1
     :include_notes_from: unreleased
 
+    .. change::
+        :tags: bug, setup
+
+        Addded ``decorator`` module to ``tox.ini`` and ``setup.py``'s
+        "tests_require" to ensure it is available for testing.
+
+
 .. changelog::
     :version: 0.9.0
     :released: Mon Oct 28 2019

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,6 @@ setup(
     """,
     zip_safe=False,
     install_requires=["decorator>=4.0.0"],
+    tests_require=["decorator>=4.0.0"],
     cmdclass={"test": UseTox},
 )

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,5 @@ setup(
     """,
     zip_safe=False,
     install_requires=["decorator>=4.0.0"],
-    tests_require=["decorator>=4.0.0"],
     cmdclass={"test": UseTox},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,8 @@ deps=
 	pytest
 	mock
 	Mako
+	decorator>=4.0.0
+
 	{memcached}: pylibmc
 
 	# the py3k python-memcached fails for multiple


### PR DESCRIPTION
I'm doing some housekeeping, and dogpile tests were failing in a new environment. I realized the required `decorator` module was not listed.