### PR TITLE
applied black formatting (v19.10b0)

### DIFF
--- a/docs/build/changelog.rst
+++ b/docs/build/changelog.rst
@@ -6,6 +6,16 @@ Changelog
     :version: 0.9.1
     :include_notes_from: unreleased
 
+    .. change::
+        :tags: feature
+
+        Applied ``black`` module formatting to this library (v19.10b0).
+
+        .. seealso::
+
+            https://pypi.org/project/black/
+
+
 .. changelog::
     :version: 0.9.0
     :released: Mon Oct 28 2019

--- a/dogpile/__init__.py
+++ b/dogpile/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.1'
+__version__ = "0.9.1"
 
 from .lock import Lock  # noqa
 from .lock import NeedRegenerationException  # noqa

--- a/dogpile/cache/backends/__init__.py
+++ b/dogpile/cache/backends/__init__.py
@@ -3,26 +3,16 @@ from ...util import PluginLoader
 _backend_loader = PluginLoader("dogpile.cache")
 register_backend = _backend_loader.register
 
+register_backend("dogpile.cache.null", "dogpile.cache.backends.null", "NullBackend")
+register_backend("dogpile.cache.dbm", "dogpile.cache.backends.file", "DBMBackend")
 register_backend(
-    "dogpile.cache.null", "dogpile.cache.backends.null", "NullBackend"
+    "dogpile.cache.pylibmc", "dogpile.cache.backends.memcached", "PylibmcBackend",
 )
 register_backend(
-    "dogpile.cache.dbm", "dogpile.cache.backends.file", "DBMBackend"
+    "dogpile.cache.bmemcached", "dogpile.cache.backends.memcached", "BMemcachedBackend",
 )
 register_backend(
-    "dogpile.cache.pylibmc",
-    "dogpile.cache.backends.memcached",
-    "PylibmcBackend",
-)
-register_backend(
-    "dogpile.cache.bmemcached",
-    "dogpile.cache.backends.memcached",
-    "BMemcachedBackend",
-)
-register_backend(
-    "dogpile.cache.memcached",
-    "dogpile.cache.backends.memcached",
-    "MemcachedBackend",
+    "dogpile.cache.memcached", "dogpile.cache.backends.memcached", "MemcachedBackend",
 )
 register_backend(
     "dogpile.cache.memory", "dogpile.cache.backends.memory", "MemoryBackend"
@@ -32,6 +22,4 @@ register_backend(
     "dogpile.cache.backends.memory",
     "MemoryPickleBackend",
 )
-register_backend(
-    "dogpile.cache.redis", "dogpile.cache.backends.redis", "RedisBackend"
-)
+register_backend("dogpile.cache.redis", "dogpile.cache.backends.redis", "RedisBackend")

--- a/dogpile/cache/backends/file.py
+++ b/dogpile/cache/backends/file.py
@@ -139,9 +139,7 @@ class DBMBackend(CacheBackend):
     """
 
     def __init__(self, arguments):
-        self.filename = os.path.abspath(
-            os.path.normpath(arguments["filename"])
-        )
+        self.filename = os.path.abspath(os.path.normpath(arguments["filename"]))
         dir_, filename = os.path.split(self.filename)
 
         self.lock_factory = arguments.get("lock_factory", FileLock)
@@ -168,9 +166,7 @@ class DBMBackend(CacheBackend):
         if argument is None:
             lock = self.lock_factory(os.path.join(basedir, basefile + suffix))
         elif argument is not False:
-            lock = self.lock_factory(
-                os.path.abspath(os.path.normpath(argument))
-            )
+            lock = self.lock_factory(os.path.abspath(os.path.normpath(argument)))
         else:
             return None
         if wrapper:
@@ -238,16 +234,12 @@ class DBMBackend(CacheBackend):
 
     def set(self, key, value):
         with self._dbm_file(True) as dbm:
-            dbm[key] = compat.pickle.dumps(
-                value, compat.pickle.HIGHEST_PROTOCOL
-            )
+            dbm[key] = compat.pickle.dumps(value, compat.pickle.HIGHEST_PROTOCOL)
 
     def set_multi(self, mapping):
         with self._dbm_file(True) as dbm:
             for key, value in mapping.items():
-                dbm[key] = compat.pickle.dumps(
-                    value, compat.pickle.HIGHEST_PROTOCOL
-                )
+                dbm[key] = compat.pickle.dumps(value, compat.pickle.HIGHEST_PROTOCOL)
 
     def delete(self, key):
         with self._dbm_file(True) as dbm:

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -158,9 +158,7 @@ class GenericMemcachedBackend(CacheBackend):
 
     def get_mutex(self, key):
         if self.distributed_lock:
-            return MemcachedLock(
-                lambda: self.client, key, timeout=self.lock_timeout
-            )
+            return MemcachedLock(lambda: self.client, key, timeout=self.lock_timeout)
         else:
             return None
 
@@ -201,9 +199,7 @@ class MemcacheArgs(object):
         if "memcached_expire_time" in arguments:
             self.set_arguments["time"] = arguments["memcached_expire_time"]
         if "min_compress_len" in arguments:
-            self.set_arguments["min_compress_len"] = arguments[
-                "min_compress_len"
-            ]
+            self.set_arguments["min_compress_len"] = arguments["min_compress_len"]
         super(MemcacheArgs, self).__init__(arguments)
 
 
@@ -254,9 +250,7 @@ class PylibmcBackend(MemcacheArgs, GenericMemcachedBackend):
         import pylibmc  # noqa
 
     def _create_client(self):
-        return pylibmc.Client(
-            self.url, binary=self.binary, behaviors=self.behaviors
-        )
+        return pylibmc.Client(self.url, binary=self.binary, behaviors=self.behaviors)
 
 
 memcache = None
@@ -345,18 +339,14 @@ class BMemcachedBackend(GenericMemcachedBackend):
 
             def add(self, key, value, timeout=0):
                 try:
-                    return super(RepairBMemcachedAPI, self).add(
-                        key, value, timeout
-                    )
+                    return super(RepairBMemcachedAPI, self).add(key, value, timeout)
                 except ValueError:
                     return False
 
         self.Client = RepairBMemcachedAPI
 
     def _create_client(self):
-        return self.Client(
-            self.url, username=self.username, password=self.password
-        )
+        return self.Client(self.url, username=self.username, password=self.password)
 
     def delete_multi(self, keys):
         """python-binary-memcached api does not implements delete_multi"""

--- a/dogpile/cache/backends/memory.py
+++ b/dogpile/cache/backends/memory.py
@@ -64,8 +64,7 @@ class MemoryBackend(CacheBackend):
         ret = [self._cache.get(key, NO_VALUE) for key in keys]
         if self.pickle_values:
             ret = [
-                pickle.loads(value) if value is not NO_VALUE else value
-                for value in ret
+                pickle.loads(value) if value is not NO_VALUE else value for value in ret
             ]
         return ret
 

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -132,10 +132,7 @@ class RedisBackend(CacheBackend):
             return redis.StrictRedis.from_url(**args)
         else:
             args.update(
-                host=self.host,
-                password=self.password,
-                port=self.port,
-                db=self.db,
+                host=self.host, password=self.password, port=self.port, db=self.db,
             )
             return redis.StrictRedis(**args)
 
@@ -171,8 +168,7 @@ class RedisBackend(CacheBackend):
 
     def set_multi(self, mapping):
         mapping = dict(
-            (k, pickle.dumps(v, pickle.HIGHEST_PROTOCOL))
-            for k, v in mapping.items()
+            (k, pickle.dumps(v, pickle.HIGHEST_PROTOCOL)) for k, v in mapping.items()
         )
 
         if not self.redis_expiration_time:

--- a/dogpile/cache/proxy.py
+++ b/dogpile/cache/proxy.py
@@ -63,9 +63,7 @@ class ProxyBackend(CacheBackend):
         Return an object that be used as a backend by a :class:`.CacheRegion`
         object.
         """
-        assert isinstance(backend, CacheBackend) or isinstance(
-            backend, ProxyBackend
-        )
+        assert isinstance(backend, CacheBackend) or isinstance(backend, ProxyBackend)
         self.proxied = backend
         return self
 

--- a/dogpile/cache/region.py
+++ b/dogpile/cache/region.py
@@ -420,8 +420,7 @@ class CacheRegion(object):
             raise exception.RegionAlreadyConfigured(
                 "This region is already "
                 "configured with backend: %s.  "
-                "Specify replace_existing_backend=True to replace."
-                % self.backend
+                "Specify replace_existing_backend=True to replace." % self.backend
             )
 
         try:
@@ -441,9 +440,7 @@ class CacheRegion(object):
         if not expiration_time or isinstance(expiration_time, Number):
             self.expiration_time = expiration_time
         elif isinstance(expiration_time, datetime.timedelta):
-            self.expiration_time = int(
-                compat.timedelta_total_seconds(expiration_time)
-            )
+            self.expiration_time = int(compat.timedelta_total_seconds(expiration_time))
         else:
             raise exception.ValidationError(
                 "expiration_time is not a number or timedelta."
@@ -473,9 +470,7 @@ class CacheRegion(object):
             proxy = proxy()
 
         if not issubclass(type(proxy), ProxyBackend):
-            raise TypeError(
-                "Type %s is not a valid ProxyBackend" % type(proxy)
-            )
+            raise TypeError("Type %s is not a valid ProxyBackend" % type(proxy))
 
         self.backend = proxy.wrap(self.backend)
 
@@ -598,9 +593,7 @@ class CacheRegion(object):
         config_dict = coerce_string_conf(config_dict)
         return self.configure(
             config_dict["%sbackend" % prefix],
-            expiration_time=config_dict.get(
-                "%sexpiration_time" % prefix, None
-            ),
+            expiration_time=config_dict.get("%sexpiration_time" % prefix, None),
             _config_argument_dict=config_dict,
             _config_prefix="%sarguments." % prefix,
             wrap=config_dict.get("%swrap" % prefix, None),
@@ -611,9 +604,7 @@ class CacheRegion(object):
 
     @memoized_property
     def backend(self):
-        raise exception.RegionNotConfigured(
-            "No backend is configured on this region."
-        )
+        raise exception.RegionNotConfigured("No backend is configured on this region.")
 
     @property
     def is_configured(self):
@@ -700,9 +691,7 @@ class CacheRegion(object):
         if self.key_mangler:
             key = self.key_mangler(key)
         value = self.backend.get(key)
-        value = self._unexpired_value_fn(expiration_time, ignore_expiration)(
-            value
-        )
+        value = self._unexpired_value_fn(expiration_time, ignore_expiration)(value)
 
         return value.payload
 
@@ -723,9 +712,7 @@ class CacheRegion(object):
                     and current_time - value.metadata["ct"] > expiration_time
                 ):
                     return NO_VALUE
-                elif self.region_invalidator.is_invalidated(
-                    value.metadata["ct"]
-                ):
+                elif self.region_invalidator.is_invalidated(value.metadata["ct"]):
                     return NO_VALUE
                 else:
                     return value
@@ -777,9 +764,7 @@ class CacheRegion(object):
         )
         return [
             value.payload if value is not NO_VALUE else value
-            for value in (
-                _unexpired_value_fn(value) for value in backend_values
-            )
+            for value in (_unexpired_value_fn(value) for value in backend_values)
         ]
 
     @contextlib.contextmanager
@@ -788,8 +773,7 @@ class CacheRegion(object):
         yield
         seconds = time.time() - start_time
         log.debug(
-            "Cache value generated in %(seconds).3f seconds for key(s): "
-            "%(keys)r",
+            "Cache value generated in %(seconds).3f seconds for key(s): " "%(keys)r",
             {"seconds": seconds, "keys": repr_obj(keys)},
         )
 
@@ -912,9 +896,7 @@ class CacheRegion(object):
         def gen_value():
             with self._log_time(orig_key):
                 if creator_args:
-                    created_value = creator(
-                        *creator_args[0], **creator_args[1]
-                    )
+                    created_value = creator(*creator_args[0], **creator_args[1])
                 else:
                     created_value = creator()
             value = self._value(created_value)
@@ -927,10 +909,7 @@ class CacheRegion(object):
         if expiration_time is None:
             expiration_time = self.expiration_time
 
-        if (
-            expiration_time is None
-            and self.region_invalidator.was_soft_invalidated()
-        ):
+        if expiration_time is None and self.region_invalidator.was_soft_invalidated():
             raise exception.DogpileCacheException(
                 "Non-None expiration time required " "for soft invalidation"
             )
@@ -955,11 +934,7 @@ class CacheRegion(object):
             async_creator = None
 
         with Lock(
-            self._mutex(key),
-            gen_value,
-            get_value,
-            expiration_time,
-            async_creator,
+            self._mutex(key), gen_value, get_value, expiration_time, async_creator,
         ) as value:
             return value
 
@@ -1035,10 +1010,7 @@ class CacheRegion(object):
         if expiration_time is None:
             expiration_time = self.expiration_time
 
-        if (
-            expiration_time is None
-            and self.region_invalidator.was_soft_invalidated()
-        ):
+        if expiration_time is None and self.region_invalidator.was_soft_invalidated():
             raise exception.DogpileCacheException(
                 "Non-None expiration time required " "for soft invalidation"
             )
@@ -1122,8 +1094,7 @@ class CacheRegion(object):
 
         if self.key_mangler:
             mapping = dict(
-                (self.key_mangler(k), self._value(v))
-                for k, v in mapping.items()
+                (self.key_mangler(k), self._value(v)) for k, v in mapping.items()
             )
         else:
             mapping = dict((k, self._value(v)) for k, v in mapping.items())
@@ -1352,9 +1323,7 @@ class CacheRegion(object):
             key = key_generator(*arg, **kw)
 
             timeout = (
-                expiration_time()
-                if expiration_time_is_callable
-                else expiration_time
+                expiration_time() if expiration_time_is_callable else expiration_time
             )
             return self.get_or_create(
                 key, user_func, timeout, should_cache_fn, (arg, kw)
@@ -1544,18 +1513,14 @@ class CacheRegion(object):
                 return user_func(*[key_lookup[k] for k in keys_to_create])
 
             timeout = (
-                expiration_time()
-                if expiration_time_is_callable
-                else expiration_time
+                expiration_time() if expiration_time_is_callable else expiration_time
             )
 
             if asdict:
 
                 def dict_create(*keys):
                     d_values = creator(*keys)
-                    return [
-                        d_values.get(key_lookup[k], NO_VALUE) for k in keys
-                    ]
+                    return [d_values.get(key_lookup[k], NO_VALUE) for k in keys]
 
                 def wrap_cache_fn(value):
                     if value is NO_VALUE:
@@ -1569,9 +1534,7 @@ class CacheRegion(object):
                     keys, dict_create, timeout, wrap_cache_fn
                 )
                 result = dict(
-                    (k, v)
-                    for k, v in zip(cache_keys, result)
-                    if v is not NO_VALUE
+                    (k, v) for k, v in zip(cache_keys, result) if v is not NO_VALUE
                 )
             else:
                 result = self.get_or_create_multi(
@@ -1594,8 +1557,7 @@ class CacheRegion(object):
                 gen_keys = key_generator(*keys)
                 self.set_multi(
                     dict(
-                        (gen_key, mapping[key])
-                        for gen_key, key in zip(gen_keys, keys)
+                        (gen_key, mapping[key]) for gen_key, key in zip(gen_keys, keys)
                     )
                 )
 

--- a/dogpile/cache/util.py
+++ b/dogpile/cache/util.py
@@ -112,9 +112,7 @@ def kwarg_function_key_generator(namespace, fn, to_str=compat.string_type):
         as_kwargs = dict(
             [
                 (argspec.args[idx], arg)
-                for idx, arg in enumerate(
-                    args[arg_index_start:], arg_index_start
-                )
+                for idx, arg in enumerate(args[arg_index_start:], arg_index_start)
             ]
         )
         as_kwargs.update(kwargs)
@@ -180,10 +178,7 @@ class repr_obj(object):
             segment_length = self.max_chars // 2
             rep = (
                 rep[0:segment_length]
-                + (
-                    " ... (%d characters truncated) ... "
-                    % (lenrep - self.max_chars)
-                )
+                + (" ... (%d characters truncated) ... " % (lenrep - self.max_chars))
                 + rep[-segment_length:]
             )
         return rep

--- a/dogpile/lock.py
+++ b/dogpile/lock.py
@@ -53,12 +53,7 @@ class Lock(object):
     """
 
     def __init__(
-        self,
-        mutex,
-        creator,
-        value_and_created_fn,
-        expiretime,
-        async_creator=None,
+        self, mutex, creator, value_and_created_fn, expiretime, async_creator=None,
     ):
         self.mutex = mutex
         self.creator = creator
@@ -71,8 +66,7 @@ class Lock(object):
         value is available."""
 
         return not self._has_value(createdtime) or (
-            self.expiretime is not None
-            and time.time() - createdtime > self.expiretime
+            self.expiretime is not None and time.time() - createdtime > self.expiretime
         )
 
     def _has_value(self, createdtime):
@@ -124,9 +118,7 @@ class Lock(object):
         if self._has_value(createdtime):
             has_value = True
             if not self.mutex.acquire(False):
-                log.debug(
-                    "creation function in progress elsewhere, returning"
-                )
+                log.debug("creation function in progress elsewhere, returning")
                 return NOT_REGENERATED
         else:
             has_value = False

--- a/dogpile/util/compat.py
+++ b/dogpile/util/compat.py
@@ -27,9 +27,7 @@ FullArgSpec = collections.namedtuple(
     ],
 )
 
-ArgSpec = collections.namedtuple(
-    "ArgSpec", ["args", "varargs", "keywords", "defaults"]
-)
+ArgSpec = collections.namedtuple("ArgSpec", ["args", "varargs", "keywords", "defaults"])
 
 
 def inspect_getfullargspec(func):
@@ -136,6 +134,4 @@ def timedelta_total_seconds(td):
     if py27:
         return td.total_seconds()
     else:
-        return (
-            td.microseconds + (td.seconds + td.days * 24 * 3600) * 1e6
-        ) / 1e6
+        return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 1e6) / 1e6

--- a/dogpile/util/langhelpers.py
+++ b/dogpile/util/langhelpers.py
@@ -40,9 +40,7 @@ class PluginLoader(object):
                 self.impls[name] = impl.load
                 return impl.load()
             else:
-                raise self.NotFound(
-                    "Can't load plugin %s %s" % (self.group, name)
-                )
+                raise self.NotFound("Can't load plugin %s %s" % (self.group, name))
 
     def register(self, name, modulepath, objname):
         def load():

--- a/dogpile/util/nameregistry.py
+++ b/dogpile/util/nameregistry.py
@@ -82,9 +82,7 @@ class NameRegistry(object):
                     )
                     return value
             except KeyError:
-                self._values[identifier] = value = self.creator(
-                    identifier, *args, **kw
-                )
+                self._values[identifier] = value = self.creator(identifier, *args, **kw)
                 return value
         finally:
             self._mutex.release()

--- a/dogpile/util/readwrite_lock.py
+++ b/dogpile/util/readwrite_lock.py
@@ -69,8 +69,7 @@ class ReadWriteMutex(object):
                     self.condition.notifyAll()
             elif self.async_ < 0:
                 raise LockError(
-                    "Synchronizer error - too many "
-                    "release_read_locks called"
+                    "Synchronizer error - too many " "release_read_locks called"
                 )
             log.debug("%s released read lock", self)
         finally:
@@ -120,8 +119,7 @@ class ReadWriteMutex(object):
         try:
             if self.current_sync_operation is not threading.currentThread():
                 raise LockError(
-                    "Synchronizer error - current thread doesn't "
-                    "have the write lock"
+                    "Synchronizer error - current thread doesn't " "have the write lock"
                 )
 
             # reset the current sync operation so

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,7 @@ class UseTox(TestCommand):
 
 v = open(os.path.join(os.path.dirname(__file__), "dogpile", "__init__.py"))
 VERSION = (
-    re.compile(r""".*__version__ = ["'](.*?)["']""", re.S)
-    .match(v.read())
-    .group(1)
+    re.compile(r""".*__version__ = ["'](.*?)["']""", re.S).match(v.read()).group(1)
 )
 v.close()
 

--- a/tests/cache/_fixtures.py
+++ b/tests/cache/_fixtures.py
@@ -148,12 +148,9 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
         reg.delete_multi(["key1", "key2", "key3", "key4", "key5"])
         values = {"key1": "value1", "key3": "value3", "key5": "value5"}
         reg.set_multi(values)
-        reg_values = reg.get_multi(
-            ["key1", "key2", "key3", "key4", "key5", "key6"]
-        )
+        reg_values = reg.get_multi(["key1", "key2", "key3", "key4", "key5", "key6"])
         eq_(
-            reg_values,
-            ["value1", NO_VALUE, "value3", NO_VALUE, "value5", NO_VALUE],
+            reg_values, ["value1", NO_VALUE, "value3", NO_VALUE, "value5", NO_VALUE],
         )
 
     def test_region_get_empty_multiple(self):
@@ -245,10 +242,7 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
         def f():
             for x in range(5):
                 reg.get_or_create_multi(
-                    [
-                        str(random.randint(1, 10))
-                        for i in range(random.randint(1, 5))
-                    ],
+                    [str(random.randint(1, 10)) for i in range(random.randint(1, 5))],
                     creator,
                 )
                 time.sleep(0.5)
@@ -316,9 +310,7 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
         def boom():
             raise Exception("boom")
 
-        assert_raises_message(
-            Exception, "boom", reg.get_or_create, "some_key", boom
-        )
+        assert_raises_message(Exception, "boom", reg.get_or_create, "some_key", boom)
 
 
 class _GenericMutexTest(_GenericBackendFixture, TestCase):

--- a/tests/cache/plugins/test_mako_cache.py
+++ b/tests/cache/plugins/test_mako_cache.py
@@ -13,9 +13,7 @@ try:
 except ImportError:
     raise pytest.skip("this test suite requires mako templates")
 
-register_plugin(
-    "dogpile.cache", "dogpile.cache.plugins.mako_cache", "MakoPlugin"
-)
+register_plugin("dogpile.cache", "dogpile.cache.plugins.mako_cache", "MakoPlugin")
 
 
 class TestMakoPlugin(TestCase):
@@ -24,10 +22,7 @@ class TestMakoPlugin(TestCase):
         reg.get_or_create.return_value = "hello world"
         my_regions = {"myregion": reg}
         return (
-            {
-                "cache_impl": "dogpile.cache",
-                "cache_args": {"regions": my_regions},
-            },
+            {"cache_impl": "dogpile.cache", "cache_args": {"regions": my_regions},},
             reg,
         )
 

--- a/tests/cache/test_dbm_backend.py
+++ b/tests/cache/test_dbm_backend.py
@@ -47,9 +47,7 @@ if has_fcntl:
 class DBMBackendConditionTest(_GenericBackendTest):
     backend = "dogpile.cache.dbm"
 
-    config_args = {
-        "arguments": {"filename": test_fname, "lock_factory": MutexLock}
-    }
+    config_args = {"arguments": {"filename": test_fname, "lock_factory": MutexLock}}
 
 
 class DBMBackendNoLockTest(_GenericBackendTest):
@@ -95,9 +93,7 @@ if has_fcntl:
 
 
 class DBMMutexConditionTest(_DBMMutexTest):
-    config_args = {
-        "arguments": {"filename": test_fname, "lock_factory": MutexLock}
-    }
+    config_args = {"arguments": {"filename": test_fname, "lock_factory": MutexLock}}
 
 
 def teardown():

--- a/tests/cache/test_decorator.py
+++ b/tests/cache/test_decorator.py
@@ -16,9 +16,7 @@ from ._fixtures import _GenericBackendFixture
 class DecoratorTest(_GenericBackendFixture, TestCase):
     backend = "dogpile.cache.memory"
 
-    def _fixture(
-        self, namespace=None, expiration_time=None, key_generator=None
-    ):
+    def _fixture(self, namespace=None, expiration_time=None, key_generator=None):
         reg = self._region(config_args={"expiration_time": 0.25})
 
         counter = itertools.count(1)
@@ -34,9 +32,7 @@ class DecoratorTest(_GenericBackendFixture, TestCase):
 
         return go
 
-    def _multi_fixture(
-        self, namespace=None, expiration_time=None, key_generator=None
-    ):
+    def _multi_fixture(self, namespace=None, expiration_time=None, key_generator=None):
 
         reg = self._region(config_args={"expiration_time": 0.25})
 
@@ -205,9 +201,7 @@ class KeyGenerationTest(TestCase):
         canary = []
 
         def decorate(fn):
-            canary.append(
-                util.function_multi_key_generator(namespace, fn, **kw)
-            )
+            canary.append(util.function_multi_key_generator(namespace, fn, **kw))
             return fn
 
         return decorate, canary
@@ -216,9 +210,7 @@ class KeyGenerationTest(TestCase):
         canary = []
 
         def decorate(fn):
-            canary.append(
-                util.kwarg_function_key_generator(namespace, fn, **kw)
-            )
+            canary.append(util.kwarg_function_key_generator(namespace, fn, **kw))
             return fn
 
         return decorate, canary
@@ -309,10 +301,7 @@ class KeyGenerationTest(TestCase):
 
         eq_(
             gen(1, 2),
-            [
-                "tests.cache.test_decorator:one|1",
-                "tests.cache.test_decorator:one|2",
-            ],
+            ["tests.cache.test_decorator:one|1", "tests.cache.test_decorator:one|2",],
         )
 
     def test_keygen_fn_namespace(self):
@@ -374,10 +363,7 @@ class KeyGenerationTest(TestCase):
 
         eq_(
             gen(compat.u("méil"), compat.u("drôle")),
-            compat.ue(
-                "tests.cache.test_decorator:"
-                "one|mynamespace|m\xe9il dr\xf4le"
-            ),
+            compat.ue("tests.cache.test_decorator:" "one|mynamespace|m\xe9il dr\xf4le"),
         )
 
     def test_unicode_key_kwarg_generator(self):
@@ -393,10 +379,7 @@ class KeyGenerationTest(TestCase):
 
         eq_(
             gen(compat.u("méil"), compat.u("drôle")),
-            compat.ue(
-                "tests.cache.test_decorator:"
-                "one|mynamespace|m\xe9il dr\xf4le"
-            ),
+            compat.ue("tests.cache.test_decorator:" "one|mynamespace|m\xe9il dr\xf4le"),
         )
 
     def test_unicode_key_multi(self):
@@ -413,12 +396,8 @@ class KeyGenerationTest(TestCase):
         eq_(
             gen(compat.u("méil"), compat.u("drôle")),
             [
-                compat.ue(
-                    "tests.cache.test_decorator:one|mynamespace|m\xe9il"
-                ),
-                compat.ue(
-                    "tests.cache.test_decorator:one|mynamespace|dr\xf4le"
-                ),
+                compat.ue("tests.cache.test_decorator:one|mynamespace|m\xe9il"),
+                compat.ue("tests.cache.test_decorator:one|mynamespace|dr\xf4le"),
             ],
         )
 
@@ -473,8 +452,7 @@ class KeyGenerationTest(TestCase):
         key = gen(1, 2)
 
         eq_(
-            util.sha1_mangle_key(key),
-            "aead490a8ace2d69a00160f1fd8fd8a16552c24f",
+            util.sha1_mangle_key(key), "aead490a8ace2d69a00160f1fd8fd8a16552c24f",
         )
 
     def test_sha1_key_mangler_unicode_py2k(self):
@@ -566,9 +544,7 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
 
         @reg.cache_multi_on_arguments(asdict=True)
         def generate(*args):
-            return dict(
-                [(arg, "%d %d" % (arg, next(counter))) for arg in args]
-            )
+            return dict([(arg, "%d %d" % (arg, next(counter))) for arg in args])
 
         eq_(generate(2, 8, 10), {2: "2 2", 8: "8 3", 10: "10 1"})
         eq_(generate(2, 9, 10), {2: "2 2", 9: "9 4", 10: "10 1"})
@@ -590,11 +566,7 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         @reg.cache_multi_on_arguments(asdict=True)
         def generate(*args):
             return dict(
-                [
-                    (arg, "%d %d" % (arg, next(counter)))
-                    for arg in args
-                    if arg != 10
-                ]
+                [(arg, "%d %d" % (arg, next(counter))) for arg in args if arg != 10]
             )
 
         eq_(generate(2, 8, 10), {2: "2 1", 8: "8 2"})
@@ -618,11 +590,7 @@ class CacheDecoratorTest(_GenericBackendFixture, TestCase):
         )
         def generate(*args):
             return dict(
-                [
-                    (arg, "%d %d" % (arg, next(counter)))
-                    for arg in args
-                    if arg != 10
-                ]
+                [(arg, "%d %d" % (arg, next(counter))) for arg in args if arg != 10]
             )
 
         eq_(generate(2, 8, 10), {2: "2 1", 8: "8 2"})

--- a/tests/cache/test_mako.py
+++ b/tests/cache/test_mako.py
@@ -11,7 +11,5 @@ class MakoTest(TestCase):
 
         # if the entrypoint isn't there, just pass, as the tests can be run
         # without any setuptools install
-        for impl in pkg_resources.iter_entry_points(
-            "mako.cache", "dogpile.cache"
-        ):
+        for impl in pkg_resources.iter_entry_points("mako.cache", "dogpile.cache"):
             impl.load()

--- a/tests/cache/test_memcached_backend.py
+++ b/tests/cache/test_memcached_backend.py
@@ -31,8 +31,7 @@ class _TestMemcachedConn(object):
         except Exception:
             if not expect_memcached_running:
                 pytest.skip(
-                    "memcached is not running or "
-                    "otherwise not functioning correctly"
+                    "memcached is not running or " "otherwise not functioning correctly"
                 )
             else:
                 raise
@@ -43,9 +42,7 @@ class _NonDistributedMemcachedTest(_TestMemcachedConn, _GenericBackendTest):
     config_args = {"arguments": {"url": MEMCACHED_URL}}
 
 
-class _DistributedMemcachedWithTimeoutTest(
-    _TestMemcachedConn, _GenericBackendTest
-):
+class _DistributedMemcachedWithTimeoutTest(_TestMemcachedConn, _GenericBackendTest):
     region_args = {"key_mangler": lambda x: x.replace(" ", "_")}
     config_args = {
         "arguments": {
@@ -58,20 +55,14 @@ class _DistributedMemcachedWithTimeoutTest(
 
 class _DistributedMemcachedTest(_TestMemcachedConn, _GenericBackendTest):
     region_args = {"key_mangler": lambda x: x.replace(" ", "_")}
-    config_args = {
-        "arguments": {"url": MEMCACHED_URL, "distributed_lock": True}
-    }
+    config_args = {"arguments": {"url": MEMCACHED_URL, "distributed_lock": True}}
 
 
 class _DistributedMemcachedMutexTest(_TestMemcachedConn, _GenericMutexTest):
-    config_args = {
-        "arguments": {"url": MEMCACHED_URL, "distributed_lock": True}
-    }
+    config_args = {"arguments": {"url": MEMCACHED_URL, "distributed_lock": True}}
 
 
-class _DistributedMemcachedMutexWithTimeoutTest(
-    _TestMemcachedConn, _GenericMutexTest
-):
+class _DistributedMemcachedMutexWithTimeoutTest(_TestMemcachedConn, _GenericMutexTest):
     config_args = {
         "arguments": {
             "url": MEMCACHED_URL,
@@ -121,9 +112,7 @@ class BMemcachedDistributedTest(BMemcachedSkips, _DistributedMemcachedTest):
     backend = "dogpile.cache.bmemcached"
 
 
-class BMemcachedDistributedMutexTest(
-    BMemcachedSkips, _DistributedMemcachedMutexTest
-):
+class BMemcachedDistributedMutexTest(BMemcachedSkips, _DistributedMemcachedMutexTest):
     backend = "dogpile.cache.bmemcached"
 
 
@@ -166,9 +155,7 @@ class MockPylibmcBackend(PylibmcBackend):
         pass
 
     def _create_client(self):
-        return MockClient(
-            self.url, binary=self.binary, behaviors=self.behaviors
-        )
+        return MockClient(self.url, binary=self.binary, behaviors=self.behaviors)
 
 
 class MockClient(object):
@@ -214,9 +201,7 @@ class PylibmcArgsTest(TestCase):
         eq_(backend._create_client().arg[0], ["foo"])
 
     def test_behaviors(self):
-        backend = MockPylibmcBackend(
-            arguments={"url": "foo", "behaviors": {"q": "p"}}
-        )
+        backend = MockPylibmcBackend(arguments={"url": "foo", "behaviors": {"q": "p"}})
         eq_(backend._create_client().kw["behaviors"], {"q": "p"})
 
     def test_set_time(self):
@@ -227,9 +212,7 @@ class PylibmcArgsTest(TestCase):
         eq_(backend._clients.memcached.canary, [{"time": 20}])
 
     def test_set_min_compress_len(self):
-        backend = MockPylibmcBackend(
-            arguments={"url": "foo", "min_compress_len": 20}
-        )
+        backend = MockPylibmcBackend(arguments={"url": "foo", "min_compress_len": 20})
         backend.set("foo", "bar")
         eq_(backend._clients.memcached.canary, [{"min_compress_len": 20}])
 
@@ -248,9 +231,7 @@ class MemcachedArgstest(TestCase):
         eq_(backend._clients.memcached.canary, [{"time": 20}])
 
     def test_set_min_compress_len(self):
-        backend = MockMemcacheBackend(
-            arguments={"url": "foo", "min_compress_len": 20}
-        )
+        backend = MockMemcacheBackend(arguments={"url": "foo", "min_compress_len": 20})
         backend.set("foo", "bar")
         eq_(backend._clients.memcached.canary, [{"min_compress_len": 20}])
 

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -26,8 +26,7 @@ class _TestRedisConn(object):
         except Exception:
             if not expect_redis_running:
                 pytest.skip(
-                    "redis is not running or "
-                    "otherwise not functioning correctly"
+                    "redis is not running or " "otherwise not functioning correctly"
                 )
             else:
                 raise
@@ -36,12 +35,7 @@ class _TestRedisConn(object):
 class RedisTest(_TestRedisConn, _GenericBackendTest):
     backend = "dogpile.cache.redis"
     config_args = {
-        "arguments": {
-            "host": REDIS_HOST,
-            "port": REDIS_PORT,
-            "db": 0,
-            "foo": "barf",
-        }
+        "arguments": {"host": REDIS_HOST, "port": REDIS_PORT, "db": 0, "foo": "barf",}
     }
 
 
@@ -118,9 +112,7 @@ class RedisConnectionTest(TestCase):
         pool = Mock()
         arguments = {"connection_pool": pool, "socket_timeout": 0.5}
         expected_args = {"connection_pool": pool}
-        self._test_helper(
-            MockStrictRedis, expected_args, connection_args=arguments
-        )
+        self._test_helper(MockStrictRedis, expected_args, connection_args=arguments)
 
     def test_connect_with_url(self, MockStrictRedis):
         arguments = {"url": "redis://redis:password@127.0.0.1:6379/0"}

--- a/tests/cache/test_region.py
+++ b/tests/cache/test_region.py
@@ -71,9 +71,7 @@ class RegionTest(TestCase):
         config = configparser.ConfigParser()
         compat.read_config_file(config, io.StringIO(my_conf))
 
-        my_region.configure_from_config(
-            dict(config.items("xyz")), "cache.example."
-        )
+        my_region.configure_from_config(dict(config.items("xyz")), "cache.example.")
         eq_(my_region.expiration_time, 600)
         assert isinstance(my_region.backend, MockBackend) is True
         eq_(
@@ -118,8 +116,7 @@ class RegionTest(TestCase):
         eq_(list(reg.backend._cache), ["HI!some key"])
         eq_(reg.get("some key"), "some value")
         eq_(
-            reg.get_or_create("some key", lambda: "some new value"),
-            "some value",
+            reg.get_or_create("some key", lambda: "some new value"), "some value",
         )
         reg.delete("some key")
         eq_(reg.get("some key"), NO_VALUE)
@@ -232,8 +229,7 @@ class RegionTest(TestCase):
         is_(reg.get("some key"), NO_VALUE)
         eq_(reg.get("some key", ignore_expiration=True), "some value 1")
         eq_(
-            reg.get_or_create("some key", creator, expiration_time=-1),
-            "some value 1",
+            reg.get_or_create("some key", creator, expiration_time=-1), "some value 1",
         )
         eq_(reg.get_or_create("some key", creator), "some value 2")
         eq_(reg.get("some key"), "some value 2")
@@ -292,14 +288,12 @@ class RegionTest(TestCase):
             return "some value %d" % next(counter)
 
         eq_(
-            reg.get_or_create("some key", creator, expiration_time=1),
-            "some value 1",
+            reg.get_or_create("some key", creator, expiration_time=1), "some value 1",
         )
         time.sleep(2)
         eq_(reg.get("some key"), "some value 1")
         eq_(
-            reg.get_or_create("some key", creator, expiration_time=1),
-            "some value 2",
+            reg.get_or_create("some key", creator, expiration_time=1), "some value 2",
         )
         eq_(reg.get("some key"), "some value 2")
 
@@ -430,22 +424,16 @@ class RegionTest(TestCase):
             return values.pop(0)
 
         should_cache_fn = lambda val: val in (1, 3)  # noqa
-        ret = reg.get_or_create(
-            "some key", creator, should_cache_fn=should_cache_fn
-        )
+        ret = reg.get_or_create("some key", creator, should_cache_fn=should_cache_fn)
         eq_(ret, 1)
         eq_(reg.backend._cache["some key"][0], 1)
         time.sleep(0.1)
         reg.invalidate()
-        ret = reg.get_or_create(
-            "some key", creator, should_cache_fn=should_cache_fn
-        )
+        ret = reg.get_or_create("some key", creator, should_cache_fn=should_cache_fn)
         eq_(ret, 2)
         eq_(reg.backend._cache["some key"][0], 1)
         reg.invalidate()
-        ret = reg.get_or_create(
-            "some key", creator, should_cache_fn=should_cache_fn
-        )
+        ret = reg.get_or_create("some key", creator, should_cache_fn=should_cache_fn)
         eq_(ret, 3)
         eq_(reg.backend._cache["some key"][0], 3)
 
@@ -458,23 +446,17 @@ class RegionTest(TestCase):
             return [v for k in keys]
 
         should_cache_fn = lambda val: val in (1, 3)  # noqa
-        ret = reg.get_or_create_multi(
-            [1, 2], creator, should_cache_fn=should_cache_fn
-        )
+        ret = reg.get_or_create_multi([1, 2], creator, should_cache_fn=should_cache_fn)
         eq_(ret, [1, 1])
         eq_(reg.backend._cache[1][0], 1)
         time.sleep(0.1)
         reg.invalidate()
-        ret = reg.get_or_create_multi(
-            [1, 2], creator, should_cache_fn=should_cache_fn
-        )
+        ret = reg.get_or_create_multi([1, 2], creator, should_cache_fn=should_cache_fn)
         eq_(ret, [2, 2])
         eq_(reg.backend._cache[1][0], 1)
         time.sleep(0.1)
         reg.invalidate()
-        ret = reg.get_or_create_multi(
-            [1, 2], creator, should_cache_fn=should_cache_fn
-        )
+        ret = reg.get_or_create_multi([1, 2], creator, should_cache_fn=should_cache_fn)
         eq_(ret, [3, 3])
         eq_(reg.backend._cache[1][0], 3)
 
@@ -545,9 +527,7 @@ class CustomInvalidationStrategyTest(RegionTest):
                 self._hard_invalidated = None
 
         def is_invalidated(self, timestamp):
-            return (
-                self._soft_invalidated and timestamp < self._soft_invalidated
-            ) or (
+            return (self._soft_invalidated and timestamp < self._soft_invalidated) or (
                 self._hard_invalidated and timestamp < self._hard_invalidated
             )
 
@@ -555,17 +535,13 @@ class CustomInvalidationStrategyTest(RegionTest):
             return bool(self._hard_invalidated)
 
         def is_hard_invalidated(self, timestamp):
-            return (
-                self._hard_invalidated and timestamp < self._hard_invalidated
-            )
+            return self._hard_invalidated and timestamp < self._hard_invalidated
 
         def was_soft_invalidated(self):
             return bool(self._soft_invalidated)
 
         def is_soft_invalidated(self, timestamp):
-            return (
-                self._soft_invalidated and timestamp < self._soft_invalidated
-            )
+            return self._soft_invalidated and timestamp < self._soft_invalidated
 
     def _region(self, init_args={}, config_args={}, backend="mock"):
         reg = CacheRegion(**init_args)
@@ -607,11 +583,7 @@ class AsyncCreatorTest(TestCase):
         eq_(reg.get_or_create("some key", some_new_value), "some new value")
         eq_(
             acr.mock_calls,
-            [
-                mock.call(
-                    reg, "some key", some_new_value, reg._mutex("some key")
-                )
-            ],
+            [mock.call(reg, "some key", some_new_value, reg._mutex("some key"))],
         )
 
     def test_fn_decorator(self):
@@ -640,8 +612,7 @@ class AsyncCreatorTest(TestCase):
         eq_(go(1, 2), 3)
 
         eq_(
-            canary.mock_calls,
-            [mock.call(1, 2), mock.call(3, 4), mock.call(1, 2)],
+            canary.mock_calls, [mock.call(1, 2), mock.call(3, 4), mock.call(1, 2)],
         )
 
         eq_(
@@ -697,9 +668,7 @@ class ProxyBackendTest(TestCase):
         """ Keep a counter of hose often we set a particular key"""
 
         def __init__(self, *args, **kwargs):
-            super(ProxyBackendTest.UsedKeysProxy, self).__init__(
-                *args, **kwargs
-            )
+            super(ProxyBackendTest.UsedKeysProxy, self).__init__(*args, **kwargs)
             self._key_count = defaultdict(lambda: 0)
 
         def setcount(self, key):
@@ -715,9 +684,7 @@ class ProxyBackendTest(TestCase):
         Never set a key that matches never_set """
 
         def __init__(self, never_set, *args, **kwargs):
-            super(ProxyBackendTest.NeverSetProxy, self).__init__(
-                *args, **kwargs
-            )
+            super(ProxyBackendTest.NeverSetProxy, self).__init__(*args, **kwargs)
             self.never_set = never_set
             self._key_count = defaultdict(lambda: 0)
 
@@ -869,10 +836,7 @@ class LoggingTest(TestCase):
                 mock.call.debug(
                     "Cache value generated in %(seconds).3f "
                     "seconds for key(s): %(keys)r",
-                    {
-                        "seconds": 5,
-                        "keys": util.repr_obj(["foo", "bar", "bat"]),
-                    },
+                    {"seconds": 5, "keys": util.repr_obj(["foo", "bar", "bat"]),},
                 )
             ],
         )
@@ -904,34 +868,28 @@ class LoggingTest(TestCase):
 
         reg = self._region()
         inv = mock.Mock(is_hard_invalidated=lambda val: True)
-        with mock.patch(
-            "dogpile.cache.region.log"
-        ) as mock_log, mock.patch.object(reg, "region_invalidator", inv):
+        with mock.patch("dogpile.cache.region.log") as mock_log, mock.patch.object(
+            reg, "region_invalidator", inv
+        ):
             is_(
                 reg._is_cache_miss(
-                    CachedValue(
-                        "some value", {"v": value_version - 5, "ct": 500}
-                    ),
+                    CachedValue("some value", {"v": value_version - 5, "ct": 500}),
                     "some key",
                 ),
                 True,
             )
         eq_(
             mock_log.mock_calls,
-            [
-                mock.call.debug(
-                    "Dogpile version update for key: %r", "some key"
-                )
-            ],
+            [mock.call.debug("Dogpile version update for key: %r", "some key")],
         )
 
     def test_log_is_hard_invalidated(self):
 
         reg = self._region()
         inv = mock.Mock(is_hard_invalidated=lambda val: True)
-        with mock.patch(
-            "dogpile.cache.region.log"
-        ) as mock_log, mock.patch.object(reg, "region_invalidator", inv):
+        with mock.patch("dogpile.cache.region.log") as mock_log, mock.patch.object(
+            reg, "region_invalidator", inv
+        ):
             is_(
                 reg._is_cache_miss(
                     CachedValue("some value", {"v": value_version, "ct": 500}),
@@ -941,9 +899,5 @@ class LoggingTest(TestCase):
             )
         eq_(
             mock_log.mock_calls,
-            [
-                mock.call.debug(
-                    "Hard invalidation detected for key: %r", "some key"
-                )
-            ],
+            [mock.call.debug("Hard invalidation detected for key: %r", "some key")],
         )

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -40,9 +40,7 @@ class ConcurrencyTest(TestCase):
         self._test_multi(10, 2, 2.5, 50, 0.05, 0.1)
 
     def test_get_value_plus_created_registry_unsafe_cache(self):
-        self._test_multi(
-            10, 1, 0.6, 100, 0.05, 0.1, cache_expire_time="unsafe"
-        )
+        self._test_multi(10, 1, 0.6, 100, 0.05, 0.1, cache_expire_time="unsafe")
 
     def test_get_value_plus_created_registry_safe_cache_quick(self):
         self._test_multi(10, 2, 0.5, 50, 0.05, 0.1, cache_expire_time="safe")
@@ -107,10 +105,7 @@ class ConcurrencyTest(TestCase):
         effective_creation_time = creation_time
 
         max_stale = (
-            effective_expiretime
-            + effective_creation_time
-            + usage_time
-            + delay_time
+            effective_expiretime + effective_creation_time + usage_time + delay_time
         ) * 1.1
 
         the_resource = []
@@ -119,9 +114,7 @@ class ConcurrencyTest(TestCase):
 
         def create_resource():
             with self._assert_synchronized():
-                log.debug(
-                    "creating resource, will take %f sec" % creation_time
-                )
+                log.debug("creating resource, will take %f sec" % creation_time)
                 time.sleep(creation_time)
 
                 if slow_write_time:
@@ -153,8 +146,7 @@ class ConcurrencyTest(TestCase):
                     # honors this).
                     self._assert_log(
                         cache_expire_time < expiretime,
-                        "Cache expiration hit, cache "
-                        "expire time %s, expiretime %s",
+                        "Cache expiration hit, cache " "expire time %s, expiretime %s",
                         cache_expire_time,
                         expiretime,
                     )
@@ -172,9 +164,7 @@ class ConcurrencyTest(TestCase):
             try:
                 for i in range(num_usages):
                     now = time.time()
-                    with Lock(
-                        mutex, create_resource, get_value, expiretime
-                    ) as value:
+                    with Lock(mutex, create_resource, get_value, expiretime) as value:
                         waited = time.time() - now
                         if waited > 0.01:
                             slow_waiters[0] += 1
@@ -213,9 +203,7 @@ class ConcurrencyTest(TestCase):
         # time spent starts with num usages * time per usage, with a 10% fudge
         expected_run_time = (num_usages * (usage_time + delay_time)) * 1.1
 
-        expected_generations = math.ceil(
-            expected_run_time / effective_expiretime
-        )
+        expected_generations = math.ceil(expected_run_time / effective_expiretime)
 
         if unsafe_cache:
             expected_slow_waiters = expected_generations * num_threads
@@ -248,9 +236,7 @@ class ConcurrencyTest(TestCase):
             delay_time,
         )
         log.info(
-            "cache expire time: %s; unsafe cache: %s",
-            cache_expire_time,
-            unsafe_cache,
+            "cache expire time: %s; unsafe cache: %s", cache_expire_time, unsafe_cache,
         )
         log.info(
             "Estimated run time %.2f actual run time %.2f",


### PR DESCRIPTION
IIRC, @zzzeek integrated ``black`` as part of SqlAlchemy's code review via commit hooks.  I'm doing some housekeeping, and figured I'd simply do a PR to reformat this library with black.

Mike, if it's easier for your workflow to just apply ``black`` on your master and push, that works too.