### PR TITLE
Fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/python/black/
+-   repo: https://github.com/python/black
     rev: 19.10b0
     hooks:
     -   id: black
 
--   repo: https://github.com/sqlalchemyorg/zimports/
+-   repo: https://github.com/sqlalchemyorg/zimports
     rev: master
     hooks:
     -   id: zimports


### PR DESCRIPTION
Trailing slash was causing errors on my machine (Ubuntu 18.04, pc 2.1.1,
git 2.17)

```
[INFO] Initializing environment for https://github.com/python/black/.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    ERROR: Repository not found.
    fatal: Could not read from remote repository.

    Please make sure you have the correct access rights
    and the repository exists.
```

I'm not sure why others haven't run into this problem before.

![Screenshot from 2020-03-11 12-44-51](https://user-images.githubusercontent.com/29210237/76457494-20843180-6396-11ea-8c47-17fe24a174fd.png)
