### PR TITLE
replace use of pkg_resources with stevedore

### DIFF
--- a/docs/build/unreleased/183.rst
+++ b/docs/build/unreleased/183.rst
@@ -1,0 +1,5 @@
+.. change::
+   :tags: feature
+
+   Improved plugin scanner performance by switching from pkg_resources
+   to stevedore.

--- a/dogpile/util/langhelpers.py
+++ b/dogpile/util/langhelpers.py
@@ -2,6 +2,8 @@ import collections
 import re
 import threading
 
+import stevedore
+
 
 def coerce_string_conf(d):
     result = {}
@@ -27,18 +29,23 @@ def coerce_string_conf(d):
 class PluginLoader(object):
     def __init__(self, group):
         self.group = group
-        self.impls = {}
+        self.impls = {}  # loaded plugins
+        self._mgr = None  # lazily defined stevedore manager
+        self._unloaded = {}  # plugins registered but not loaded
 
     def load(self, name):
+        if name in self._unloaded:
+            self.impls[name] = self._unloaded[name]()
+            return self.impls[name]
         if name in self.impls:
-            return self.impls[name]()
+            return self.impls[name]
         else:  # pragma NO COVERAGE
-            import pkg_resources
-
-            for impl in pkg_resources.iter_entry_points(self.group, name):
-                self.impls[name] = impl.load
-                return impl.load()
-            else:
+            if self._mgr is None:
+                self._mgr = stevedore.ExtensionManager(self.group)
+            try:
+                self.impls[name] = self._mgr[name].plugin
+                return self.impls[name]
+            except KeyError:
                 raise self.NotFound(
                     "Can't load plugin %s %s" % (self.group, name)
                 )
@@ -48,7 +55,7 @@ class PluginLoader(object):
             mod = __import__(modulepath, fromlist=[objname])
             return getattr(mod, objname)
 
-        self.impls[name] = load
+        self._unloaded[name] = load
 
     class NotFound(Exception):
         """The specified plugin could not be found."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ project_urls =
 [options]
 install_requires =
   decorator>=4.0.0
+  stevedore>=3.0.0
 zip_safe = False
 packages = find:
 python_requires = >=3.5


### PR DESCRIPTION
Importing pkg_resources has a side-effect of scanning all installed
distributions for entry point data. Stevedore 3.0 uses
a cache in front of importlib.metadata to load the same information more
efficiently, which can improve application startup time.