### PR TITLE
Use built-in unittest.mock instead of external mock

### DIFF
--- a/tests/cache/plugins/test_mako_cache.py
+++ b/tests/cache/plugins/test_mako_cache.py
@@ -1,8 +1,8 @@
+from unittest import mock
 from unittest import TestCase
 
 from mako.cache import register_plugin
 from mako.template import Template
-import mock
 import pytest
 
 from .. import eq_

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -3,9 +3,9 @@ import os
 from threading import Event
 import time
 from unittest import TestCase
+from unittest.mock import Mock
+from unittest.mock import patch
 
-from mock import Mock
-from mock import patch
 import pytest
 
 from dogpile.cache.region import _backend_loader

--- a/tests/cache/test_region.py
+++ b/tests/cache/test_region.py
@@ -4,9 +4,8 @@ import datetime
 import io
 import itertools
 import time
+from unittest import mock
 from unittest import TestCase
-
-import mock
 
 from dogpile.cache import CacheRegion
 from dogpile.cache import exception

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -3,9 +3,8 @@ import logging
 import math
 import threading
 import time
+from unittest import mock
 from unittest import TestCase
-
-import mock
 
 from dogpile import Lock
 from dogpile import NeedRegenerationException

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ setenv=
 
 deps=
 	pytest
-	mock
 	Mako
 	decorator>=4.0.0
 	# Needed for an async runner test.


### PR DESCRIPTION
Python 3 has a builtin unittest.mock module that is equivalent
to the external mock (in fact, the latter has become a backport
of the former), so just use it instead of introducing unnecessary
dependency.