### PR TITLE
Allow custom pickler/unpickler for redis backend

### DIFF
--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -1,3 +1,4 @@
+import pickle
 from concurrent.futures import ThreadPoolExecutor
 import os
 from threading import Event
@@ -46,6 +47,19 @@ class RedisTest(_TestRedisConn, _GenericBackendTest):
             "port": REDIS_PORT,
             "db": 0,
             "foo": "barf",
+        }
+    }
+
+
+class RedisCustomPickleParamsTest(_TestRedisConn, _GenericBackendTest):
+    backend = "dogpile.cache.redis"
+    config_args = {
+        "arguments": {
+            "host": REDIS_HOST,
+            "port": REDIS_PORT,
+            "db": 0,
+            "pickler": lambda value: b'XX' + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL),
+            "unpickler": lambda value: pickle.loads(value[2:]),
         }
     }
 

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -58,7 +58,9 @@ class RedisCustomPickleParamsTest(_TestRedisConn, _GenericBackendTest):
             "host": REDIS_HOST,
             "port": REDIS_PORT,
             "db": 0,
-            "pickler": lambda value: b'XX' + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL),
+            "pickler": lambda value: (
+                b"XX" + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+            ),
             "unpickler": lambda value: pickle.loads(value[2:]),
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,6 @@ def is_unittest(obj):
 
 def pytest_pycollect_makeitem(collector, name, obj):
     if is_unittest(obj) and not obj.__name__.startswith("_"):
-        return UnitTestCase(name, parent=collector)
+        return UnitTestCase.from_parent(name=name, parent=collector)
     else:
         return []

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ setenv=
 
 
 deps=
-	pytest
+	pytest>=5.4.0
 	Mako
 	decorator>=4.0.0
 	# Needed for an async runner test.


### PR DESCRIPTION
RedisBackend serializes values using `pickle.HIGEST_PROTOCOL`. I find it a debatable choice, since it won't allow workers using different python versions to cooperatively use a redis cache. For example, workers using python 3.6 will fail to read values generated by workers with python 3.8.
In my opinion, `pickle.DEFAULT_PROTOCOL` is a more sensible choice.

Currently there is no way to override how values are pickled in the RedisBackend.

This PR introduces 2 new parameters to the RedisBackend, `pickler` and `unpickler`, that default to `pickle.dumps` (where the DEFAULT_PROTOCOL is used) and `pickle.loads`.
In this way users have more control over how values are serialized (and deserialized) from redis.

Potentially, one could use a completely different serialization protocol.

I see that other backends hardcode pickle invocations. Maybe this should be more generic and be part of the CacheBackend class?