### PR TITLE
Decouple serialization logic from CacheBackend classes

### DIFF
--- a/dogpile/cache/api.py
+++ b/dogpile/cache/api.py
@@ -79,7 +79,6 @@ class CacheBackend(object):
          passed to :func:`.make_registry`.
 
         """
-        # TODO: Maybe use just one single object, like Serializer, and delegate to it
 
         serializer = arguments.get("serializer")
         if serializer is None:

--- a/dogpile/cache/api.py
+++ b/dogpile/cache/api.py
@@ -79,29 +79,18 @@ class CacheBackend(object):
          passed to :func:`.make_registry`.
 
         """
-        # TODO: We can probably use a better name than pickler/unpickler,
-        #  as pickle is just one of the possible protocols to use
-        #  Maybe use just one single object, like Serializer, and delegate to it
+        # TODO: Maybe use just one single object, like Serializer, and delegate to it
 
-        # For example, it could look like this:
-        # class AConcreteBackend(CacheBackend):
-        #     def set(self, key, value):
-        #         value = self.serializer.serialize(value)
-        #         self.client.set(key, value)
-        #     def get(self, key):
-        #         value = self.client.get(key)
-        #         return self.serializer.deserialize(value)
+        serializer = arguments.get("serializer")
+        if serializer is None:
+            serializer = _noop
 
-        pickler = arguments.get("pickler")
-        if pickler is None:
-            pickler = _noop
+        deserializer = arguments.get("deserializer")
+        if deserializer is None:
+            deserializer = _noop
 
-        unpickler = arguments.get("unpickler")
-        if unpickler is None:
-            unpickler = _noop
-
-        self.pickler = pickler
-        self.unpickler = unpickler
+        self.serializer = serializer
+        self.deserializer = deserializer
 
     @classmethod
     def from_config_dict(cls, config_dict, prefix):

--- a/dogpile/cache/api.py
+++ b/dogpile/cache/api.py
@@ -1,6 +1,10 @@
 import operator
 
 
+def _noop(x):
+    return x
+
+
 class NoValue(object):
     """Describe a missing cache value.
 
@@ -75,7 +79,29 @@ class CacheBackend(object):
          passed to :func:`.make_registry`.
 
         """
-        raise NotImplementedError()
+        # TODO: We can probably use a better name than pickler/unpickler,
+        #  as pickle is just one of the possible protocols to use
+        #  Maybe use just one single object, like Serializer, and delegate to it
+
+        # For example, it could look like this:
+        # class AConcreteBackend(CacheBackend):
+        #     def set(self, key, value):
+        #         value = self.serializer.serialize(value)
+        #         self.client.set(key, value)
+        #     def get(self, key):
+        #         value = self.client.get(key)
+        #         return self.serializer.deserialize(value)
+
+        pickler = arguments.get("pickler")
+        if pickler is None:
+            pickler = _noop
+
+        unpickler = arguments.get("unpickler")
+        if unpickler is None:
+            unpickler = _noop
+
+        self.pickler = pickler
+        self.unpickler = unpickler
 
     @classmethod
     def from_config_dict(cls, config_dict, prefix):

--- a/dogpile/cache/backends/file.py
+++ b/dogpile/cache/backends/file.py
@@ -140,6 +140,13 @@ class DBMBackend(CacheBackend):
     """
 
     def __init__(self, arguments):
+        super().__init__(
+            {
+                "pickler": pickle.dumps,
+                "unpickler": pickle.loads,
+                **arguments
+            },
+        )
         self.filename = os.path.abspath(
             os.path.normpath(arguments["filename"])
         )

--- a/dogpile/cache/backends/file.py
+++ b/dogpile/cache/backends/file.py
@@ -144,7 +144,7 @@ class DBMBackend(CacheBackend):
             {
                 "serializer": pickle.dumps,
                 "deserializer": pickle.loads,
-                **arguments
+                **arguments,
             },
         )
         self.filename = os.path.abspath(

--- a/dogpile/cache/backends/file.py
+++ b/dogpile/cache/backends/file.py
@@ -142,8 +142,8 @@ class DBMBackend(CacheBackend):
     def __init__(self, arguments):
         super().__init__(
             {
-                "pickler": pickle.dumps,
-                "unpickler": pickle.loads,
+                "serializer": pickle.dumps,
+                "deserializer": pickle.loads,
                 **arguments
             },
         )
@@ -235,7 +235,7 @@ class DBMBackend(CacheBackend):
                 except KeyError:
                     value = NO_VALUE
             if value is not NO_VALUE:
-                value = pickle.loads(value)
+                value = self.deserializer(value)
             return value
 
     def get_multi(self, keys):
@@ -243,12 +243,12 @@ class DBMBackend(CacheBackend):
 
     def set(self, key, value):
         with self._dbm_file(True) as dbm:
-            dbm[key] = pickle.dumps(value, pickle.HIGHEST_PROTOCOL)
+            dbm[key] = self.serializer(value)
 
     def set_multi(self, mapping):
         with self._dbm_file(True) as dbm:
             for key, value in mapping.items():
-                dbm[key] = pickle.dumps(value, pickle.HIGHEST_PROTOCOL)
+                dbm[key] = self.serializer(value)
 
     def delete(self, key):
         with self._dbm_file(True) as dbm:

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -112,6 +112,11 @@ class GenericMemcachedBackend(CacheBackend):
     to the :meth:`set` method."""
 
     def __init__(self, arguments):
+        # No need to override serializer, as all the memcached libraries will do it.
+        # Still, we support customizing the serializer/deserializer to use better default pickle protocol
+        # or completely different serialization mechanism
+
+        super().__init__(arguments)
         self._imports()
         # using a plain threading.local here.   threading.local
         # automatically deletes the __dict__ when a thread ends,

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -179,14 +179,17 @@ class GenericMemcachedBackend(CacheBackend):
 
     def get_multi(self, keys):
         values = self.client.get_multi(keys)
-        return [NO_VALUE if key not in values else self.deserializer(values[key]) for key in keys]
+        return [
+            NO_VALUE if key not in values else self.deserializer(values[key])
+            for key in keys
+        ]
 
     def set(self, key, value):
         self.client.set(key, self.serializer(value), **self.set_arguments)
 
     def set_multi(self, mapping):
         mapping = {
-            key: self.serializer(value) for key, value in mapping
+            key: self.serializer(value) for key, value in mapping.items()
         }
         self.client.set_multi(mapping, **self.set_arguments)
 

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -175,16 +175,19 @@ class GenericMemcachedBackend(CacheBackend):
         if value is None:
             return NO_VALUE
         else:
-            return value
+            return self.deserializer(value)
 
     def get_multi(self, keys):
         values = self.client.get_multi(keys)
-        return [NO_VALUE if key not in values else values[key] for key in keys]
+        return [NO_VALUE if key not in values else self.deserializer(values[key]) for key in keys]
 
     def set(self, key, value):
-        self.client.set(key, value, **self.set_arguments)
+        self.client.set(key, self.serializer(value), **self.set_arguments)
 
     def set_multi(self, mapping):
+        mapping = {
+            key: self.serializer(value) for key, value in mapping
+        }
         self.client.set_multi(mapping, **self.set_arguments)
 
     def delete(self, key):

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -112,8 +112,9 @@ class GenericMemcachedBackend(CacheBackend):
     to the :meth:`set` method."""
 
     def __init__(self, arguments):
-        # No need to override serializer, as all the memcached libraries will do it.
-        # Still, we support customizing the serializer/deserializer to use better default pickle protocol
+        # No need to override serializer, as all the memcached libraries
+        # handles that themselves. Still, we support customizing the
+        # serializer/deserializer to use better default pickle protocol
         # or completely different serialization mechanism
 
         super().__init__(arguments)

--- a/dogpile/cache/backends/memory.py
+++ b/dogpile/cache/backends/memory.py
@@ -57,24 +57,24 @@ class MemoryBackend(CacheBackend):
     def get(self, key):
         value = self._cache.get(key, NO_VALUE)
         if value is not NO_VALUE:
-            value = self.unpickler(value)
+            value = self.deserializer(value)
         return value
 
     def get_multi(self, keys):
         raw_values = [self._cache.get(key, NO_VALUE) for key in keys]
         values = [
-            self.unpickler(value) if value is not NO_VALUE else value
+            self.deserializer(value) if value is not NO_VALUE else value
             for value in raw_values
         ]
         return values
 
     def set(self, key, value):
-        value = self.pickler(value)
+        value = self.serializer(value)
         self._cache[key] = value
 
     def set_multi(self, mapping):
         for key, value in mapping.items():
-            value = self.pickler(value)
+            value = self.serializer(value)
             self._cache[key] = value
 
     def delete(self, key):
@@ -120,8 +120,8 @@ class MemoryPickleBackend(MemoryBackend):
     def __init__(self, arguments):
         super().__init__(
             {
-                "pickler": pickle.dumps,
-                "unpickler": pickle.loads,
+                "serializer": pickle.dumps,
+                "deserializer": pickle.loads,
                 **arguments
             },
         )

--- a/dogpile/cache/backends/memory.py
+++ b/dogpile/cache/backends/memory.py
@@ -122,6 +122,6 @@ class MemoryPickleBackend(MemoryBackend):
             {
                 "serializer": pickle.dumps,
                 "deserializer": pickle.loads,
-                **arguments
+                **arguments,
             },
         )

--- a/dogpile/cache/backends/null.py
+++ b/dogpile/cache/backends/null.py
@@ -38,9 +38,6 @@ class NullBackend(CacheBackend):
 
     """
 
-    def __init__(self, arguments):
-        pass
-
     def get_mutex(self, key):
         return NullLock()
 

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -191,12 +191,13 @@ class RedisBackend(CacheBackend):
         ]
 
     def set(self, key, value):
+        serialized = self.serializer(value)
         if self.redis_expiration_time:
             self.writer_client.setex(
-                key, self.redis_expiration_time, self.serializer(value),
+                key, self.redis_expiration_time, serialized,
             )
         else:
-            self.writer_client.set(key, self.serializer(value))
+            self.writer_client.set(key, serialized)
 
     def set_multi(self, mapping):
         mapping = dict((k, self.serializer(v)) for k, v in mapping.items())

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -295,30 +295,20 @@ class RedisSentinelBackend(RedisBackend):
     """
 
     def __init__(self, arguments):
-        # TODO: Call super(), so that serializer, deserializer are correctly initialized
         arguments = arguments.copy()
-        self._imports()
-        self.password = arguments.pop("password", None)
-        self.db = arguments.pop("db", 0)
-        self.distributed_lock = arguments.get("distributed_lock", True)
-        self.socket_timeout = arguments.pop("socket_timeout", None)
+
         self.sentinels = arguments.pop("sentinels", None)
         self.service_name = arguments.pop("service_name", "mymaster")
         self.sentinel_kwargs = arguments.pop("sentinel_kwargs", {})
         self.connection_kwargs = arguments.pop("connection_kwargs", {})
 
-        self.lock_timeout = arguments.get("lock_timeout", None)
-        self.lock_sleep = arguments.get("lock_sleep", 0.1)
-        self.thread_local_lock = arguments.get("thread_local_lock", False)
-
-        if self.distributed_lock and self.thread_local_lock:
-            warnings.warn(
-                "The Redis backend thread_local_lock parameter should be "
-                "set to False when distributed_lock is True"
-            )
-
-        self.redis_expiration_time = arguments.pop("redis_expiration_time", 0)
-        self._create_client()
+        super().__init__(
+            arguments={
+                "distributed_lock": True,
+                "thread_local_lock": False,
+                 **arguments
+            },
+        )
 
     def _imports(self):
         # defer imports until backend is used

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -101,6 +101,13 @@ class RedisBackend(CacheBackend):
     """
 
     def __init__(self, arguments):
+        super().__init__(
+            {
+                "pickler": pickle.dumps,
+                "unpickler": pickle.loads,
+                **arguments
+            },
+        )
         arguments = arguments.copy()
         self._imports()
         self.url = arguments.pop("url", None)
@@ -114,8 +121,6 @@ class RedisBackend(CacheBackend):
         self.lock_timeout = arguments.get("lock_timeout", None)
         self.lock_sleep = arguments.get("lock_sleep", 0.1)
         self.thread_local_lock = arguments.get("thread_local_lock", True)
-        self.pickler = arguments.get("pickler", pickle.dumps)
-        self.unpickler = arguments.get("unpickler", pickle.loads)
 
         if self.distributed_lock and self.thread_local_lock:
             warnings.warn(
@@ -290,6 +295,7 @@ class RedisSentinelBackend(RedisBackend):
     """
 
     def __init__(self, arguments):
+        # TODO: Call super(), so that pickler, unpickler are correctly initialized
         arguments = arguments.copy()
         self._imports()
         self.password = arguments.pop("password", None)

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -105,7 +105,7 @@ class RedisBackend(CacheBackend):
             {
                 "serializer": pickle.dumps,
                 "deserializer": pickle.loads,
-                **arguments
+                **arguments,
             },
         )
         arguments = arguments.copy()
@@ -186,25 +186,20 @@ class RedisBackend(CacheBackend):
         if not keys:
             return []
         values = self.reader_client.mget(keys)
-        return [self.deserializer(v) if v is not None else NO_VALUE for v in values]
+        return [
+            self.deserializer(v) if v is not None else NO_VALUE for v in values
+        ]
 
     def set(self, key, value):
         if self.redis_expiration_time:
             self.writer_client.setex(
-                key,
-                self.redis_expiration_time,
-                self.serializer(value),
+                key, self.redis_expiration_time, self.serializer(value),
             )
         else:
-            self.writer_client.set(
-                key, self.serializer(value)
-            )
+            self.writer_client.set(key, self.serializer(value))
 
     def set_multi(self, mapping):
-        mapping = dict(
-            (k, self.serializer(v))
-            for k, v in mapping.items()
-        )
+        mapping = dict((k, self.serializer(v)) for k, v in mapping.items())
 
         if not self.redis_expiration_time:
             self.writer_client.mset(mapping)
@@ -306,7 +301,7 @@ class RedisSentinelBackend(RedisBackend):
             arguments={
                 "distributed_lock": True,
                 "thread_local_lock": False,
-                 **arguments
+                **arguments,
             },
         )
 

--- a/dogpile/cache/proxy.py
+++ b/dogpile/cache/proxy.py
@@ -56,6 +56,7 @@ class ProxyBackend(CacheBackend):
     """
 
     def __init__(self, *args, **kwargs):
+        super().__init__({})
         self.proxied = None
 
     def wrap(self, backend):

--- a/tests/cache/_fixtures.py
+++ b/tests/cache/_fixtures.py
@@ -252,6 +252,7 @@ class _GenericBackendTest(_GenericBackendFixture, TestCase):
                 time.sleep(0.5)
 
         f()
+        # TODO: Is this test doing anything useful, given that we return here?
         return
         threads = [Thread(target=f) for i in range(5)]
         for t in threads:

--- a/tests/cache/test_dbm_backend.py
+++ b/tests/cache/test_dbm_backend.py
@@ -6,6 +6,7 @@ from dogpile.util.readwrite_lock import ReadWriteMutex
 from . import assert_raises_message
 from ._fixtures import _GenericBackendTest
 from ._fixtures import _GenericMutexTest
+from ._fixtures import _GenericSerializerTest
 
 try:
     import fcntl  # noqa
@@ -50,6 +51,12 @@ class DBMBackendConditionTest(_GenericBackendTest):
     config_args = {
         "arguments": {"filename": test_fname, "lock_factory": MutexLock}
     }
+
+
+class DBMBackendSerializerTest(
+    _GenericSerializerTest, DBMBackendConditionTest
+):
+    pass
 
 
 class DBMBackendNoLockTest(_GenericBackendTest):

--- a/tests/cache/test_memcached_backend.py
+++ b/tests/cache/test_memcached_backend.py
@@ -13,6 +13,7 @@ from dogpile.cache.backends.memcached import PylibmcBackend
 from . import eq_
 from ._fixtures import _GenericBackendTest
 from ._fixtures import _GenericMutexTest
+from ._fixtures import _GenericSerializerTest
 
 
 MEMCACHED_PORT = os.getenv("DOGPILE_MEMCACHED_PORT", "11211")
@@ -71,10 +72,7 @@ class _NonDistributedTLSMemcachedTest(
 ):
     region_args = {"key_mangler": lambda x: x.replace(" ", "_")}
     config_args = {
-        "arguments": {
-            "url": TLS_MEMCACHED_URL,
-            "tls_context": TLS_CONTEXT,
-        }
+        "arguments": {"url": TLS_MEMCACHED_URL, "tls_context": TLS_CONTEXT}
     }
 
 
@@ -128,6 +126,12 @@ class PylibmcDistributedMutexTest(_DistributedMemcachedMutexTest):
     backend = "dogpile.cache.pylibmc"
 
 
+class PylibmcSerializerTest(
+    _GenericSerializerTest, _NonDistributedMemcachedTest
+):
+    backend = "dogpile.cache.pylibmc"
+
+
 class BMemcachedTest(_NonDistributedMemcachedTest):
     backend = "dogpile.cache.bmemcached"
 
@@ -156,6 +160,12 @@ class BMemcachedDistributedMutexWithTimeoutTest(
     backend = "dogpile.cache.bmemcached"
 
 
+class BMemcachedSerializerTest(
+    _GenericSerializerTest, _NonDistributedMemcachedTest
+):
+    backend = "dogpile.cache.bmemcached"
+
+
 class MemcachedTest(_NonDistributedMemcachedTest):
     backend = "dogpile.cache.memcached"
 
@@ -166,6 +176,12 @@ class MemcachedDistributedTest(_DistributedMemcachedTest):
 
 class MemcachedDistributedMutexTest(_DistributedMemcachedMutexTest):
     backend = "dogpile.cache.memcached"
+
+
+class MemcachedSerializerTest(
+    _GenericSerializerTest, _NonDistributedMemcachedTest
+):
+    backend = "dogpile.cache.pylibmc"
 
 
 class MockGenericMemcachedBackend(GenericMemcachedBackend):

--- a/tests/cache/test_memory_backend.py
+++ b/tests/cache/test_memory_backend.py
@@ -1,8 +1,13 @@
 from ._fixtures import _GenericBackendTest
+from ._fixtures import _GenericSerializerTest
 
 
 class MemoryBackendTest(_GenericBackendTest):
     backend = "dogpile.cache.memory"
+
+
+class MemoryBackendSerializerTest(_GenericSerializerTest, MemoryBackendTest):
+    pass
 
 
 class MemoryPickleBackendTest(_GenericBackendTest):

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -1,6 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
 import os
-import pickle
 from threading import Event
 import time
 from unittest import TestCase
@@ -14,6 +13,7 @@ from . import eq_
 from ._fixtures import _GenericBackendFixture
 from ._fixtures import _GenericBackendTest
 from ._fixtures import _GenericMutexTest
+from ._fixtures import _GenericSerializerTest
 
 REDIS_HOST = "127.0.0.1"
 REDIS_PORT = int(os.getenv("DOGPILE_REDIS_PORT", "6379"))
@@ -50,20 +50,8 @@ class RedisTest(_TestRedisConn, _GenericBackendTest):
     }
 
 
-# TODO: This can probably be a test that we should run for every backend
-class RedisCustomSerializerTest(_TestRedisConn, _GenericBackendTest):
-    backend = "dogpile.cache.redis"
-    config_args = {
-        "arguments": {
-            "host": REDIS_HOST,
-            "port": REDIS_PORT,
-            "db": 0,
-            "serializer": lambda value: (
-                b"XX" + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
-            ),
-            "deserializer": lambda value: pickle.loads(value[2:]),
-        }
-    }
+class RedisSerializerTest(_GenericSerializerTest, RedisTest):
+    pass
 
 
 class RedisDistributedMutexTest(_TestRedisConn, _GenericMutexTest):

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -24,7 +24,6 @@ class _TestRedisConn(object):
     @classmethod
     def _check_backend_available(cls, backend):
         try:
-            backend._create_client()
             backend.set("x", "y")
             # on py3k it appears to return b"y"
             assert backend.get("x") == "y"

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -1,3 +1,4 @@
+import pickle
 from concurrent.futures import ThreadPoolExecutor
 import os
 from threading import Event
@@ -46,6 +47,19 @@ class RedisTest(_TestRedisConn, _GenericBackendTest):
             "port": REDIS_PORT,
             "db": 0,
             "foo": "barf",
+        }
+    }
+
+
+class RedisCustomPickleParamsTest(_TestRedisConn, _GenericBackendTest):
+    backend = "dogpile.cache.redis"
+    config_args = {
+        "arguments": {
+            "host": REDIS_HOST,
+            "port": REDIS_PORT,
+            "db": 0,
+            "pickler": lambda value: b'XX' + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL),
+            "unpickler": lambda value: pickle.loads(value[2:]),
         }
     }
 

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -58,7 +58,9 @@ class RedisCustomPickleParamsTest(_TestRedisConn, _GenericBackendTest):
             "host": REDIS_HOST,
             "port": REDIS_PORT,
             "db": 0,
-            "pickler": lambda value: b'XX' + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL),
+            "pickler": lambda value: (
+                b"XX" + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+            ),
             "unpickler": lambda value: pickle.loads(value[2:]),
         }
     }

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -1,6 +1,6 @@
-import pickle
 from concurrent.futures import ThreadPoolExecutor
 import os
+import pickle
 from threading import Event
 import time
 from unittest import TestCase

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -58,10 +58,10 @@ class RedisCustomPickleParamsTest(_TestRedisConn, _GenericBackendTest):
             "host": REDIS_HOST,
             "port": REDIS_PORT,
             "db": 0,
-            "pickler": lambda value: (
+            "serializer": lambda value: (
                 b"XX" + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
             ),
-            "unpickler": lambda value: pickle.loads(value[2:]),
+            "deserializer": lambda value: pickle.loads(value[2:]),
         }
     }
 

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -51,7 +51,8 @@ class RedisTest(_TestRedisConn, _GenericBackendTest):
     }
 
 
-class RedisCustomPickleParamsTest(_TestRedisConn, _GenericBackendTest):
+# TODO: This can probably be a test that we should run for every backend
+class RedisCustomSerializerTest(_TestRedisConn, _GenericBackendTest):
     backend = "dogpile.cache.redis"
     config_args = {
         "arguments": {

--- a/tests/cache/test_redis_sentinel_backend.py
+++ b/tests/cache/test_redis_sentinel_backend.py
@@ -18,7 +18,6 @@ expect_redis_running = os.getenv("DOGPILE_REDIS_SENTINEL_PORT") is not None
 
 
 class _TestRedisSentinelConn(object):
-
     @classmethod
     def _check_backend_available(cls, backend):
         try:
@@ -48,7 +47,9 @@ class RedisSentinelTest(_TestRedisSentinelConn, _GenericBackendTest):
     }
 
 
-class RedisSentinelCustomSerializerTest(_TestRedisSentinelConn, _GenericBackendTest):
+class RedisSentinelCustomSerializerTest(
+    _TestRedisSentinelConn, _GenericBackendTest
+):
     backend = "dogpile.cache.redis"
     config_args = {
         "arguments": {

--- a/tests/cache/test_redis_sentinel_backend.py
+++ b/tests/cache/test_redis_sentinel_backend.py
@@ -1,6 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
 import os
-import pickle
 from threading import Event
 import time
 from unittest import TestCase
@@ -11,6 +10,7 @@ from . import eq_
 from ._fixtures import _GenericBackendFixture
 from ._fixtures import _GenericBackendTest
 from ._fixtures import _GenericMutexTest
+from ._fixtures import _GenericSerializerTest
 
 REDIS_HOST = "127.0.0.1"
 REDIS_PORT = int(os.getenv("DOGPILE_REDIS_SENTINEL_PORT", "26379"))
@@ -47,22 +47,8 @@ class RedisSentinelTest(_TestRedisSentinelConn, _GenericBackendTest):
     }
 
 
-class RedisSentinelCustomSerializerTest(
-    _TestRedisSentinelConn, _GenericBackendTest
-):
-    backend = "dogpile.cache.redis_sentinel"
-    config_args = {
-        "arguments": {
-            "sentinels": [[REDIS_HOST, REDIS_PORT]],
-            "service_name": "pifpaf",
-            "db": 0,
-            "distributed_lock": False,
-            "serializer": lambda value: (
-                b"XX" + pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
-            ),
-            "deserializer": lambda value: pickle.loads(value[2:]),
-        }
-    }
+class RedisSerializerTest(_GenericSerializerTest, RedisSentinelTest):
+    pass
 
 
 class RedisSentinelDistributedMutexTest(

--- a/tests/cache/test_redis_sentinel_backend.py
+++ b/tests/cache/test_redis_sentinel_backend.py
@@ -1,6 +1,6 @@
-import pickle
 from concurrent.futures import ThreadPoolExecutor
 import os
+import pickle
 from threading import Event
 import time
 from unittest import TestCase

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,6 @@ def is_unittest(obj):
 
 def pytest_pycollect_makeitem(collector, name, obj):
     if is_unittest(obj) and not obj.__name__.startswith("_"):
-        return UnitTestCase(name, parent=collector)
+        return UnitTestCase.from_parent(name=name, parent=collector)
     else:
         return []

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ setenv=
 
 
 deps=
-	pytest
+	pytest>=5.4.0
 	Mako
 	decorator>=4.0.0
 	# Needed for an async runner test.


### PR DESCRIPTION
This PR is a continuation of https://github.com/sqlalchemy/dogpile.cache/pull/190.

The idea is to have CacheBackend subclasses decoupled from the serialization logic. The serializer/deserialzier can be fully configured by the end user, but each subclass can default to something that makes sense for each backend library.

For example, Redis client and file system only works with bytes objects, Memcached clients (pylibmc, python-memcached, bmemcached) can work with all sort of objects, but they have debatable defaults for the pickle protocol they use.
Memory clients can work with all sort of objects too, and they don't need to pickle.