### PR TITLE
Support pytest 6

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,6 @@ def is_unittest(obj):
 
 def pytest_pycollect_makeitem(collector, name, obj):
     if is_unittest(obj) and not obj.__name__.startswith("_"):
-        return UnitTestCase(name, parent=collector)
+        return UnitTestCase.from_parent(collector, name=name)
     else:
         return []


### PR DESCRIPTION
Hi,
This makes tests pass with pytest 6.
See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent