### PR TITLE
Allow to pass pymemcache socket keepalive and allow to instantiate a RetryingClient

### DIFF
--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -173,11 +173,7 @@ class RedisBackend(BytesBackend):
 
     def set_serialized(self, key, value):
         if self.redis_expiration_time:
-            self.writer_client.setex(
-                key,
-                self.redis_expiration_time,
-                value,
-            )
+            self.writer_client.setex(key, self.redis_expiration_time, value)
         else:
             self.writer_client.set(key, value)
 
@@ -283,7 +279,7 @@ class RedisSentinelBackend(RedisBackend):
                 "distributed_lock": True,
                 "thread_local_lock": False,
                 **arguments,
-            },
+            }
         )
 
     def _imports(self):

--- a/tests/cache/test_memcached_backend.py
+++ b/tests/cache/test_memcached_backend.py
@@ -200,6 +200,17 @@ class PyMemcacheSerializerTest(
     backend = "dogpile.cache.pymemcache"
 
 
+class PyMemcacheRetryTest(_NonDistributedMemcachedTest):
+    backend = "dogpile.cache.pymemcache"
+    config_args = {
+        "arguments": {
+            "url": MEMCACHED_URL,
+            "enable_retry_client": True,
+            "retry_attempts": 3,
+        }
+    }
+
+
 class MemcachedTest(_NonDistributedMemcachedTest):
     backend = "dogpile.cache.memcached"
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,8 @@ usedevelop=True
 basepython = python3
 deps=
     mypy
+    types-decorator
+    types-redis
     redis
     Mako
     decorator

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps=
     {memcached}: python-memcached
     {memcached}: python-binary-memcached>=0.29.0
     {memcached}: pifpaf>=2.5.0
-    {memcached}: pymemcache>=3.1.0
+    {memcached}: pymemcache>=3.5.0
     {redis}: redis
     {redis}: pifpaf
     {redis_sentinel}: redis


### PR DESCRIPTION
This is the combinaison of two commits to implement and reflect new pymemcache features on the dogpile.cache side.

The first one is, the socket keepalive. These capabilities have been introduced [1][2][3] with pymemcache 3.5.0 [4][5]. These changes allow to pass keepalive configuration to the pymemcache client.

The second one is the retry mechanisms. Retry mechanisms have been implemented [6][7] with pymemcache 3.5.0 [8]. These changes allow to instantiate a ``RetryingClient`` by using dogpile.cache.

[1] https://github.com/pinterest/pymemcache/commit/b289c87bb89b3ab477bd5d92c8951ab42c923923
[2] https://github.com/pinterest/pymemcache/commit/c782de1cac7cfaf4f6868d17682197022dad2d6b
[3] https://github.com/pinterest/pymemcache/commit/4d46f5ad8ddbd860e5219965df0714bdc15062f6
[4] https://github.com/pinterest/pymemcache/commit/07b5ecc21ce5d388d4312c943d79f813311e349f
[5] https://pypi.org/project/pymemcache/3.5.0/
[6] pinterest/pymemcache@75fe5c8
[7] https://pymemcache.readthedocs.io/en/latest/getting_started.html#using-the-built-in-retrying-mechanism
[8] pinterest/pymemcache@07b5ecc

Change-Id: Ia2e76475943bc8ec86b5974217d1c92110be5b43