### PR TITLE
Add 'extras_require' section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,24 @@ pifpaf = [
     "pifpaf>=2.5.0",
     "setuptools;python_version>='3.12'",
 ]
+pymemcache = [
+    "pymemcache",
+]
+memcached = [
+    "python-memcached",
+]
+bmemcached = [
+    "python-binary-memcached",
+]
+pylibmc = [
+    "pylibmc",
+]
+redis = [
+    "redis",
+]
 
 [project.entry-points."mako.cache"]
 "dogpile.cache" = "dogpile.cache.plugins.mako_cache:MakoPlugin"
-
 
 [tool.setuptools]
 zip-safe = false


### PR DESCRIPTION
This is isn't really necessary, but it does make the necessary requirements a little more discoverable and allows dependent libraries and projects to avoid "vendoring" dogpile's own dependencies.
