### PR TITLE
Add support of dead_retry and socket_timeout for memcached backend

### DIFF
--- a/docs/build/unreleased/223.rst
+++ b/docs/build/unreleased/223.rst
@@ -1,0 +1,8 @@
+.. change::
+       :tags: usecase, memcached
+       :tickets: 223
+
+       Added :paramref:`.MemcacheArgs.dead_retry` and
+       :paramref:`.MemcacheArgs.socket_timeout` to the dictionary of
+       additional keyword arguments that will be passed
+       directly to ``GenericMemcachedBackend()``.

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -221,6 +221,15 @@ class MemcacheArgs(GenericMemcachedBackend):
     """Mixin which provides support for the 'time' argument to set(),
     'min_compress_len' to other methods.
 
+    :param dead_retry: Number of seconds memcached server is considered dead
+       before it is tried again..
+
+     .. versionadded:: 1.1.7
+
+    :param socket_timeout: Timeout in seconds for every call to a server.
+
+     .. versionadded:: 1.1.7
+
     """
 
     def __init__(self, arguments):
@@ -233,6 +242,10 @@ class MemcacheArgs(GenericMemcachedBackend):
             self.set_arguments["min_compress_len"] = arguments[
                 "min_compress_len"
             ]
+        if "dead_retry" in arguments:
+            self.set_arguments["dead_retry"] = arguments["dead_retry"]
+        if "socket_timeout" in arguments:
+            self.set_arguments["socket_timeout"] = arguments["socket_timeout"]
         super(MemcacheArgs, self).__init__(arguments)
 
 

--- a/tests/cache/test_memcached_backend.py
+++ b/tests/cache/test_memcached_backend.py
@@ -476,6 +476,26 @@ class MemcachedArgstest(TestCase):
         backend.set("foo", "bar")
         eq_(backend._clients.memcached.canary, [{"min_compress_len": 20}])
 
+    def test_set_dead_retry(self):
+        config_args = {
+            "url": "127.0.0.1:11211",
+            "dead_retry": 4,
+        }
+
+        backend = MockMemcacheBackend(arguments=config_args)
+        backend.set("foo", "bar")
+        eq_(backend._clients.memcached.canary, [{"dead_retry": 4}])
+
+    def test_set_socket_timeout(self):
+        config_args = {
+            "url": "127.0.0.1:11211",
+            "socket_timeout": 4,
+        }
+
+        backend = MockMemcacheBackend(arguments=config_args)
+        backend.set("foo", "bar")
+        eq_(backend._clients.memcached.canary, [{"socket_timeout": 4}])
+
 
 class LocalThreadTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Added :paramref:`.MemcacheArgs.dead_retry` and
:paramref:`.MemcacheArgs.socket_timeout` to the dictionary of
additional keyword arguments that will be passed
directly to ``GenericMemcachedBackend()``.

Thanks to François Rigault for assistance.
Closes: #223

Co-Authored-By: François Rigault <frigo@amadeus.com>