### PR TITLE
Move dead_retry and socket_timeout into the MemcachedBackend class

### DIFF
--- a/docs/build/unreleased/224.rst
+++ b/docs/build/unreleased/224.rst
@@ -1,0 +1,11 @@
+.. change::
+       :tags: usecase, memcached
+       :tickets: 224
+
+       Moves the :paramref:``.MemcacheArgs.dead_retry`` argument and the
+       :paramref:``.MemcacheArgs.socket_timeout`` argument which were
+       erroneously added to the "set_parameters" (:class:``.MemcacheArgs``),
+       where they have no effect, to be part of the Memcached connection
+       arguments (:paramref:``.MemcachedBackend.dead_retry``,
+       :paramref:``.MemcacheArgs.socket_timeout``).
+

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -220,16 +220,6 @@ class GenericMemcachedBackend(CacheBackend):
 class MemcacheArgs(GenericMemcachedBackend):
     """Mixin which provides support for the 'time' argument to set(),
     'min_compress_len' to other methods.
-
-    :param dead_retry: Number of seconds memcached server is considered dead
-       before it is tried again..
-
-     .. versionadded:: 1.1.7
-
-    :param socket_timeout: Timeout in seconds for every call to a server.
-
-     .. versionadded:: 1.1.7
-
     """
 
     def __init__(self, arguments):
@@ -242,10 +232,6 @@ class MemcacheArgs(GenericMemcachedBackend):
             self.set_arguments["min_compress_len"] = arguments[
                 "min_compress_len"
             ]
-        if "dead_retry" in arguments:
-            self.set_arguments["dead_retry"] = arguments["dead_retry"]
-        if "socket_timeout" in arguments:
-            self.set_arguments["socket_timeout"] = arguments["socket_timeout"]
         super(MemcacheArgs, self).__init__(arguments)
 
 
@@ -316,14 +302,43 @@ class MemcachedBackend(MemcacheArgs, GenericMemcachedBackend):
             }
         )
 
+    :param dead_retry: Number of seconds memcached server is considered dead
+       before it is tried again. Will be passed to ``memcache.Client``
+       as the ``dead_retry`` parameter.
+
+     .. versionadded:: 1.1.8
+
+     .. verisionchanged:: 1.1.8  Moved the ``dead_retry`` argument which was
+       erroneously added to the "set_parameters", where it has no effect, to
+       be part of the Memcached connection arguments.
+
+    :param socket_timeout: Timeout in seconds for every call to a server.
+       Will be passed to ``memcache.Client`` as the ``socket_timeout``
+       parameter.
+
+     .. versionadded:: 1.1.8
+
+     .. verisionchanged:: 1.1.8  Moved the ``socket_timeout`` argument which
+       was erroneously added to the "set_parameters", where it has no effect,
+       to be part of the Memcached connection arguments.
+
     """
+
+    def __init__(self, arguments):
+        self.dead_retry = arguments.get("dead_retry", 30)
+        self.socket_timeout = arguments.get("socket_timeout", 3)
+        super(MemcachedBackend, self).__init__(arguments)
 
     def _imports(self):
         global memcache
         import memcache  # noqa
 
     def _create_client(self):
-        return memcache.Client(self.url)
+        return memcache.Client(
+            self.url,
+            dead_retry=self.dead_retry,
+            socket_timeout=self.socket_timeout,
+        )
 
 
 class BMemcachedBackend(GenericMemcachedBackend):


### PR DESCRIPTION
In my previous patch [1] I proposed to add the dead_retry and socket_timeoutparams to the MemcacheArgs. I was wrong. My goal was to pass these parameters to the client during its initialization to set the memcached client dead_retry and socket_timeout arguments.

By using the MemcacheArgs they are passed to the method calls which is not what it was requested in the feature request [2]. I misunderstood the goal of this class (MemcacheArgs).

My previous patch led to issues [3][4] that I'm able to reproduce locally by using oslo.cache's functional test. These changes fix these issues.

[1] https://github.com/sqlalchemy/dogpile.cache/commit/1de93aab14c1274f20c1f44f8adff3b143c864f6
[2] https://github.com/sqlalchemy/dogpile.cache/issues/223
[3] https://bugzilla.redhat.com/show_bug.cgi?id=2103117
[4] https://review.opendev.org/c/openstack/requirements/+/848827