### PR TITLE
allow deserializer to return NO_VALUE

### DIFF
--- a/dogpile/cache/region.py
+++ b/dogpile/cache/region.py
@@ -390,7 +390,7 @@ class CacheRegion:
         function_multi_key_generator: FunctionMultiKeyGenerator = function_multi_key_generator,  # noqa E501
         key_mangler: Optional[Callable[[KeyType], KeyType]] = None,
         serializer: Optional[Callable[[ValuePayload], bytes]] = None,
-        deserializer: Optional[Callable[[bytes], ValuePayload]] = None,
+        deserializer: Optional[Callable[[bytes], Union[ValuePayload, NoValue]]] = None,
         async_creation_runner: Optional[AsyncCreator] = None,
     ):
         """Construct a new :class:`.CacheRegion`."""
@@ -1220,6 +1220,8 @@ class CacheRegion:
         bytes_metadata, _, bytes_payload = byte_value.partition(b"|")
         metadata = json.loads(bytes_metadata)
         payload = self.deserializer(bytes_payload)
+        if payload is NO_VALUE:
+            return NO_VALUE
         return CachedValue(payload, metadata)
 
     def _serialize_cached_value_elements(

--- a/tests/cache/test_memory_backend.py
+++ b/tests/cache/test_memory_backend.py
@@ -1,5 +1,11 @@
+import json
+from unittest import TestCase
+
+from dogpile.cache.api import NO_VALUE
+from ._fixtures import _GenericBackendFixture
 from ._fixtures import _GenericBackendTest
 from ._fixtures import _GenericSerializerTest
+from . import eq_
 
 
 class MemoryBackendTest(_GenericBackendTest):
@@ -8,6 +14,25 @@ class MemoryBackendTest(_GenericBackendTest):
 
 class MemoryBackendSerializerTest(_GenericSerializerTest, MemoryBackendTest):
     pass
+
+
+class MemoryBackendSerializerNoValueTest(_GenericBackendFixture, TestCase):
+    backend = "dogpile.cache.memory"
+
+    region_args = {
+        "serializer": lambda v: json.dumps(v).encode("ascii"),
+        "deserializer": lambda v: NO_VALUE,
+    }
+
+    def test_serializer_no_value(self):
+        region = self._region()
+
+        value = {"foo": ["bar", 1, False, None]}
+        region.set("k", value)
+
+        asserted = region.get("k")
+
+        eq_(asserted, NO_VALUE)
 
 
 class MemoryPickleBackendTest(_GenericBackendTest):


### PR DESCRIPTION
I have the case that our deserializer can sometimes raise an error (due to a class being moved and `pickle` not being able to find the serialized class.) As a workaround, I've overridden `CacheRegion._parse_serialized_from_backend` to catch any exceptions returned by the deserializer. 
However, it would be useful to be able to return NO_VALUE from the deserializer, then I can move the exception catching logic into the deserializer and not have to override the internal method.