### PR TITLE
Update RedisBackend documentation

### DIFF
--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -44,8 +44,9 @@ class RedisBackend(BytesBackend):
 
     Arguments accepted in the arguments dictionary:
 
-    :param url: string. If provided, will override separate host/port/db
-     params.  The format is that accepted by ``StrictRedis.from_url()``.
+    :param url: string. If provided, will override separate
+     host/password/port/db params.  The format is that accepted by
+     ``StrictRedis.from_url()``.
 
     :param host: string, default is ``localhost``.
 


### PR DESCRIPTION
Modify documentation to indicate that specifying `url` also overrides the `password` parameter.

Fixes #245