### PR TITLE
Add region.get_age(key)

### DIFF
--- a/docs/build/unreleased/247.rst
+++ b/docs/build/unreleased/247.rst
@@ -1,0 +1,17 @@
+.. change::
+    :tags: feature, region
+    :tickets: 247
+
+    Added new method :meth:`.CacheRegion.get_value_metadata` which can be used to get
+    a value from the cache associated with its metadata in the form of an instance of
+    :class:`ValueMetadata`.
+
+    At the current time, the only metadata is `cached_time` which gives the time at
+    which the value was inserted in the cache (according to `time.time()` on the
+    machine which inserted the value).
+
+    A property :meth:`.ValueMetadata.age` is available on :class:`ValueMetadata`
+    returning the elapsed time in seconds as a `float` since the insertion of the
+    value in the cache.
+    This can be useful in the context of a web server where clients may expect an
+    `Age` header, see `RFC 9111 <https://www.rfc-editor.org/rfc/rfc9111#field.age>`_.

--- a/dogpile/cache/api.py
+++ b/dogpile/cache/api.py
@@ -1,5 +1,7 @@
 import abc
+from dataclasses import dataclass
 import pickle
+import time
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -548,3 +550,22 @@ class BytesBackend(DefaultSerialization, CacheBackend):
 
         """
         raise NotImplementedError()
+
+
+@dataclass(frozen=True)
+class ValueMetadata:
+    """Holds a value from the cache and associated metadata.
+
+    At the current time, the only metadata is `cached_time` which gives the
+    time at which the value was inserted in the cache (according to
+    `time.time()` on the machine which inserted the value).
+    """
+
+    value: ValuePayload
+    cached_time: float
+
+    @property
+    def age(self) -> float:
+        """Returns the elapsed time in seconds as a `float` since the insertion
+        of the value in the cache."""
+        return time.time() - self.cached_time


### PR DESCRIPTION
See also issue https://github.com/sqlalchemy/dogpile.cache/issues/37.

It would be useful to be able to get the age of a value in the cache. Especially in the context of a web server, where clients may expect an `Age` header to know when they need to refresh (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Age).