### PR TITLE
Add support for Redis Cluster

### DIFF
--- a/dogpile/cache/backends/__init__.py
+++ b/dogpile/cache/backends/__init__.py
@@ -45,3 +45,8 @@ register_backend(
     "dogpile.cache.backends.redis",
     "RedisSentinelBackend",
 )
+register_backend(
+    "dogpile.cache.redis_cluster",
+    "dogpile.cache.backends.redis",
+    "RedisClusterBackend",
+)

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -368,6 +368,34 @@ class RedisClusterBackend(RedisBackend):
             }
         )
 
+    It is recommanded to use startup nodes, since it won't fail to connect as long as one of the node is available.
+    If you need to pass connection argument, like password, username or CA certificate, you can do it with connection_kwargs::
+
+        from dogpile.cache import make_region
+        from redis.cluster import ClusterNode
+
+        connection_kwargs = {
+            "username": "admin",
+            "password": "averystrongpassword",
+            "ssl": True,
+            "ssl_ca_certs": "redis.pem",
+        }
+
+        nodes = [
+            ClusterNode("localhost", 6379),
+            ClusterNode("localhost", 6380),
+            ClusterNode("localhost", 6381),
+        ]
+
+        region = make_region().configure(
+            "dogpile.cache.redis_cluster",
+            arguments={
+                "startup_nodes": nodes,
+                "connection_kwargs": connection_kwargs,
+            },
+        )
+
+
     Example configuration, using url and a single node::
 
         from dogpile.cache import make_region
@@ -444,7 +472,6 @@ class RedisClusterBackend(RedisBackend):
                 self.url, **self.connection_kwargs
             )
         else:
-            print(f"DEBUG CO KWARG: {self.connection_kwargs}")
             redis_cluster = redis.cluster.RedisCluster(
                 startup_nodes=self.startup_nodes,
                 **self.connection_kwargs,

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -396,7 +396,8 @@ class RedisClusterBackend(RedisBackend):
         )
 
 
-    Example configuration, using url and a single node::
+    You can also pass an url to one node, and it will discover the whole cluster
+    automatically::
 
         from dogpile.cache import make_region
 
@@ -406,6 +407,9 @@ class RedisClusterBackend(RedisBackend):
                 "url": "localhost:6379/0"
             }
         )
+
+    This is not recommanded as, if the single node is down, you won't be able to connect
+    to the cluster.
 
     Arguments accepted in the arguments dictionary:
 
@@ -437,12 +441,6 @@ class RedisClusterBackend(RedisBackend):
     :param lock_sleep: integer, number of seconds to sleep when failed to
      acquire a lock.  This argument is only valid when
      ``distributed_lock`` is ``True``.
-
-    :param connection_pool: ``redis.ConnectionPool`` object.  If provided,
-     this object supersedes other connection arguments passed to the
-     ``redis.StrictRedis`` instance, including url and/or host as well as
-     socket_timeout, and will be passed to ``redis.StrictRedis`` as the
-     source of connectivity.
 
     :param thread_local_lock: bool, whether a thread-local Redis lock object
      should be used. This is the default, but is not compatible with

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -375,21 +375,18 @@ class RedisClusterBackend(RedisBackend):
         region = make_region().configure(
             'dogpile.cache.redis_cluster',
             arguments = {
-                "url": "redis://myuser:mypassword@localhost:6379/0"
+                "url": "localhost:6379/0"
             }
         )
 
     Arguments accepted in the arguments dictionary:
 
+    :param startup_nodes: List of ClusterNode. The list of nodes in
+    the cluster that the client will try to connect to.
+
     :param url: string. If provided, will override separate
      host/password/port/db params.  The format is that accepted by
      ``RedisCluster.from_url()``.
-
-    :param host: string, default is ``localhost``.
-
-    :param password: string, default is no password.
-
-    :param port: integer, default is ``6379``.
 
     :param db: integer, default is ``0``.
 
@@ -447,14 +444,10 @@ class RedisClusterBackend(RedisBackend):
                 self.url, **self.connection_kwargs
             )
         else:
+            print(f"DEBUG CO KWARG: {self.connection_kwargs}")
             redis_cluster = redis.cluster.RedisCluster(
-                host=self.host,
-                port=self.port,
                 startup_nodes=self.startup_nodes,
-                url=self.url,
                 **self.connection_kwargs,
             )
-            if self.db != 0:
-                redis_cluster.select(self.db)
         self.writer_client = redis_cluster
         self.reader_client = self.writer_client

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -443,7 +443,9 @@ class RedisClusterBackend(RedisBackend):
 
     def _create_client(self):
         if self.url is not None:
-            redis_cluster = redis.cluster.RedisCluster.from_url(self.url)
+            redis_cluster = redis.cluster.RedisCluster.from_url(
+                self.url, **self.connection_kwargs
+            )
         else:
             redis_cluster = redis.cluster.RedisCluster(
                 host=self.host,

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -434,8 +434,8 @@ class RedisClusterBackend(RedisBackend):
 
     def __init__(self, arguments):
         arguments = arguments.copy()
-        super().__init__(arguments)
         self.startup_nodes = arguments.pop("startup_nodes", None)
+        super().__init__(arguments)
 
     def _imports(self):
         global redis

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -364,7 +364,7 @@ class RedisClusterBackend(RedisBackend):
         region = make_region().configure(
             'dogpile.cache.redis_cluster',
             arguments = {
-                startup_nodes = [ClusterNode('localhost', 6379), ClusterNode('localhost', 6378)]
+                "startup_nodes": [ClusterNode('localhost', 6379), ClusterNode('localhost', 6378)]
             }
         )
 
@@ -375,7 +375,7 @@ class RedisClusterBackend(RedisBackend):
         region = make_region().configure(
             'dogpile.cache.redis_cluster',
             arguments = {
-                url = "redis://myuser:mypassword@localhost:6379/0"
+                "url": "redis://myuser:mypassword@localhost:6379/0"
             }
         )
 

--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -18,7 +18,7 @@ else:
     # delayed import
     redis = None  # noqa F811
 
-__all__ = ("RedisBackend", "RedisSentinelBackend")
+__all__ = ("RedisBackend", "RedisSentinelBackend", "RedisClusterBackend")
 
 
 class RedisBackend(BytesBackend):
@@ -345,9 +345,6 @@ class RedisClusterBackend(RedisBackend):
 
         # Doc: https://redis.readthedocs.io/en/stable/clustering.html
         self.startup_nodes = arguments.pop("startup_nodes", None)
-
-        # TODO Understand why in the sentinel they force distributed lock at true.
-        # https://github.com/leandromoreira/redlock-rb/issues/63
 
     def _imports(self):
         global redis


### PR DESCRIPTION
Hello!

This PR aim to add the support for Redis Cluster: https://redis.io/docs/management/scaling/
This is different than Redis Sentinel, which is already supported.

Since this is a bit more complicated to use than a normal redis instance, I try to put more complete example in the documentation.
Redis Cluster is supported since version 4.1 of redis-py, so it should be pretty stable.

Open to feedback :)  