### PR TITLE
pymemcache: Add support for memcached_expire_time

### DIFF
--- a/docs/build/unreleased/pymemcache-expire.rst
+++ b/docs/build/unreleased/pymemcache-expire.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: usecase, memcached
+    :ticket: 254
+
+    Added support for an additional pymemcached client parameter
+    :paramref:`.PyMemcacheBackend.memcached_expire_time`.

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -95,26 +95,6 @@ class GenericMemcachedBackend(CacheBackend):
 
      .. versionadded:: 0.5.7
 
-    :param memcached_expire_time: integer, when present will
-     be passed as the ``time`` parameter to ``pylibmc.Client.set``.
-     This is used to set the memcached expiry time for a value.
-
-     .. note::
-
-         This parameter is **different** from Dogpile's own
-         ``expiration_time``, which is the number of seconds after
-         which Dogpile will consider the value to be expired.
-         When Dogpile considers a value to be expired,
-         it **continues to use the value** until generation
-         of a new value is complete, when using
-         :meth:`.CacheRegion.get_or_create`.
-         Therefore, if you are setting ``memcached_expire_time``, you'll
-         want to make sure it is greater than ``expiration_time``
-         by at least enough seconds for new values to be generated,
-         else the value won't be available during a regeneration,
-         forcing all threads to wait for a regeneration each time
-         a value expires.
-
     The :class:`.GenericMemachedBackend` uses a ``threading.local()``
     object to store individual client objects per thread,
     as most modern memcached clients do not appear to be inherently
@@ -222,6 +202,29 @@ class GenericMemcachedBackend(CacheBackend):
 class MemcacheArgs(GenericMemcachedBackend):
     """Mixin which provides support for the 'time' argument to set(),
     'min_compress_len' to other methods.
+
+    :param memcached_expire_time: integer, when present will
+     be passed as the ``time`` parameter to the ``set`` method.
+     This is used to set the memcached expiry time for a value.
+
+     .. note::
+
+         This parameter is **different** from Dogpile's own
+         ``expiration_time``, which is the number of seconds after
+         which Dogpile will consider the value to be expired.
+         When Dogpile considers a value to be expired,
+         it **continues to use the value** until generation
+         of a new value is complete, when using
+         :meth:`.CacheRegion.get_or_create`.
+         Therefore, if you are setting ``memcached_expire_time``, you'll
+         want to make sure it is greater than ``expiration_time``
+         by at least enough seconds for new values to be generated,
+         else the value won't be available during a regeneration,
+         forcing all threads to wait for a regeneration each time
+         a value expires.
+
+    :param min_compress_len: Threshold length to kick in auto-compression
+     of the value using the compressor
     """
 
     def __init__(self, arguments):

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -565,6 +565,28 @@ class PyMemcacheBackend(GenericMemcachedBackend):
 
      .. versionadded:: 1.1.5
 
+    :param memcached_expire_time: integer, when present will
+     be passed as the ``time`` parameter to the ``set`` method.
+     This is used to set the memcached expiry time for a value.
+
+     .. note::
+
+         This parameter is **different** from Dogpile's own
+         ``expiration_time``, which is the number of seconds after
+         which Dogpile will consider the value to be expired.
+         When Dogpile considers a value to be expired,
+         it **continues to use the value** until generation
+         of a new value is complete, when using
+         :meth:`.CacheRegion.get_or_create`.
+         Therefore, if you are setting ``memcached_expire_time``, you'll
+         want to make sure it is greater than ``expiration_time``
+         by at least enough seconds for new values to be generated,
+         else the value won't be available during a regeneration,
+         forcing all threads to wait for a regeneration each time
+         a value expires.
+
+     .. versionadded:: 1.3.3
+
     """  # noqa E501
 
     def __init__(self, arguments):
@@ -596,6 +618,9 @@ class PyMemcacheBackend(GenericMemcachedBackend):
                 "enable_retry_client is not set; retry options "
                 "will be ignored"
             )
+        self.set_arguments = {}
+        if "memcached_expire_time" in arguments:
+            self.set_arguments["expire"] = arguments["memcached_expire_time"]
 
     def _imports(self):
         global pymemcache

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -127,7 +127,6 @@ class GenericMemcachedBackend(CacheBackend):
         self.url = util.to_list(arguments["url"])
         self.distributed_lock = arguments.get("distributed_lock", False)
         self.lock_timeout = arguments.get("lock_timeout", 0)
-        self.memcached_expire_time = arguments.get("memcached_expire_time", 0)
 
     def has_lock_timeout(self):
         return self.lock_timeout != 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 enable-extensions = G
 # E203 is due to https://github.com/PyCQA/pycodestyle/issues/373
 ignore =
-    A003,
+    A003,A005,
     D,
     E203,E305,E711,E712,E721,E722,E741,
     N801,N802,N806,

--- a/tests/cache/test_memcached_backend.py
+++ b/tests/cache/test_memcached_backend.py
@@ -345,6 +345,16 @@ class PyMemcacheArgsTest:
                     ),
                 )
 
+    def test_set_time(self):
+        config_args = {"url": "127.0.0.1:11211", "memcached_expire_time": 20}
+        with self._mock_pymemcache_fixture():
+            backend = MockPyMemcacheBackend(config_args)
+            backend.set("foo", "bar")
+            eq_(
+                self.hash_client().set.mock_calls,
+                [mock.call("foo", "bar", expire=20)],
+            )
+
 
 class MemcachedTest(_NonDistributedMemcachedTestSuite):
     backend = "dogpile.cache.memcached"


### PR DESCRIPTION
The memcached_expire_time parameter is used to define the expiration set in memcached. This makes memcached actually purge data after the expiration.

This change allows users to use this feature in pymemcache backend.