### PR TITLE
Fix missing dependency definition for valkey backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ pylibmc = [
 redis = [
     "redis",
 ]
+valkey = [
+    "valkey",
+]
 
 [project.entry-points."mako.cache"]
 "dogpile.cache" = "dogpile.cache.plugins.mako_cache:MakoPlugin"


### PR DESCRIPTION
Add entry to define the optional dependency for valkey backend, following the existing entry for redis backend.