### PR TITLE
fix: make `dogpile.cache.memory` preserve its init parameters

### DIFF
--- a/dogpile/cache/backends/memory.py
+++ b/dogpile/cache/backends/memory.py
@@ -50,7 +50,7 @@ class MemoryBackend(CacheBackend):
     """
 
     def __init__(self, arguments):
-        self._cache = arguments.pop("cache_dict", {})
+        self._cache = arguments.get("cache_dict", {})
 
     def get(self, key):
         return self._cache.get(key, NO_VALUE)

--- a/tests/cache/test_memory_backend.py
+++ b/tests/cache/test_memory_backend.py
@@ -4,6 +4,10 @@ from dogpile.testing.fixtures import _GenericSerializerTestSuite
 
 class MemoryBackendTest(_GenericBackendTestSuite):
     backend = "dogpile.cache.memory"
+    config_args = {"arguments": {"cache_dict": {}}}
+
+    def test_config_args_does_not_mutate(self):
+        assert "cache_dict" in self.config_args["arguments"]
 
 
 class MemoryBackendSerializerTest(
@@ -12,5 +16,5 @@ class MemoryBackendSerializerTest(
     pass
 
 
-class MemoryPickleBackendTest(_GenericBackendTestSuite):
+class MemoryPickleBackendTest(MemoryBackendTest):
     backend = "dogpile.cache.memory_pickle"


### PR DESCRIPTION
Make the `MemoryBackend` behave like the others, and stop removing keys from the initialization dict.

Fixes: Issue #273