### PR TITLE
Custom lock prefix

### DIFF
--- a/dogpile/cache/backends/redis.py
+++ b/dogpile/cache/backends/redis.py
@@ -6,6 +6,7 @@ Provides backends for talking to `Redis <http://redis.io>`__.
 
 """
 
+import re
 import typing
 import warnings
 
@@ -19,6 +20,9 @@ else:
     redis = None  # noqa F811
 
 __all__ = ("RedisBackend", "RedisSentinelBackend", "RedisClusterBackend")
+
+
+RE_VALID_PREFIX = re.compile(r"^[\w\-\.\:]{2,10}$")
 
 
 class RedisBackend(BytesBackend):
@@ -87,6 +91,12 @@ class RedisBackend(BytesBackend):
 
      .. versionadded:: 1.4.1
 
+    :param lock_prefix: string. This prefix is used for generating the name of
+     locks. If customized, the prefix must be between 2 and 10 characters long,
+     and may contain any alphanumeric character and the symbols "_-.:".
+
+     .. versionadded:: 1.4.2
+
     :param socket_timeout: float, seconds for socket timeout.
      Default is None (no timeout).
 
@@ -132,6 +142,8 @@ class RedisBackend(BytesBackend):
      .. versionadded:: 1.1.6
     """
 
+    lock_template: str = "_lock{0}"
+
     def __init__(self, arguments):
         arguments = arguments.copy()
         self._imports()
@@ -173,6 +185,16 @@ class RedisBackend(BytesBackend):
 
         self.redis_expiration_time = arguments.pop("redis_expiration_time", 0)
         self.connection_pool = arguments.pop("connection_pool", None)
+
+        lock_prefix = arguments.pop("lock_prefix", None)
+        if lock_prefix:
+            if (not isinstance(lock_prefix, str)) or (
+                not RE_VALID_PREFIX.match(lock_prefix)
+            ):
+                raise ValueError(
+                    "Invalid `lock_prefix` submitted: `%s`." % lock_prefix
+                )
+            self.lock_template = "%s{0}" % lock_prefix
 
         self._create_client()
 
@@ -225,7 +247,7 @@ class RedisBackend(BytesBackend):
         if self.distributed_lock:
             return _RedisLockWrapper(
                 self.writer_client.lock(
-                    "_lock{0}".format(key),
+                    self.lock_template.format(key),
                     timeout=self.lock_timeout,
                     sleep=self.lock_sleep,
                     thread_local=self.thread_local_lock,

--- a/tests/cache/test_redis_backend.py
+++ b/tests/cache/test_redis_backend.py
@@ -64,6 +64,19 @@ class RedisDistributedMutexTest(_TestRedisConn, _GenericMutexTestSuite):
     }
 
 
+class RedisDistributedMutexPrefixTest(_TestRedisConn, _GenericMutexTestSuite):
+    backend = "dogpile.cache.redis"
+    config_args = {
+        "arguments": {
+            "host": REDIS_HOST,
+            "port": REDIS_PORT,
+            "db": 0,
+            "distributed_lock": True,
+            "lock_prefix": "_lok.",
+        }
+    }
+
+
 class RedisAsyncCreationTest(_TestRedisConn, _GenericBackendFixture):
     backend = "dogpile.cache.redis"
     config_args = {

--- a/tests/cache/test_valkey_backend.py
+++ b/tests/cache/test_valkey_backend.py
@@ -64,6 +64,21 @@ class ValkeyDistributedMutexTest(_TestValkeyConn, _GenericMutexTestSuite):
     }
 
 
+class ValkeyDistributedMutexPrefixTest(
+    _TestValkeyConn, _GenericMutexTestSuite
+):
+    backend = "dogpile.cache.valkey"
+    config_args = {
+        "arguments": {
+            "host": VALKEY_HOST,
+            "port": VALKEY_PORT,
+            "db": 0,
+            "distributed_lock": True,
+            "lock_prefix": "_lok.",
+        }
+    }
+
+
 class ValkeyAsyncCreationTest(_TestValkeyConn, _GenericBackendFixture):
     backend = "dogpile.cache.valkey"
     config_args = {


### PR DESCRIPTION
Extends Redis/Valkey with a "lock_prefix" argument, which allows users to override the default "_lock{0}" template.

I proposed this 10 years ago, and have been using it in a custom backend.  I keep forgetting to turn this into a PR.

The rationale for this PR: The current design uses a template of `"_lock{0}" % key` which can be visually confusing to scan during manual audits: _lockkey1, _lockkey2, etc.  This PR allows for `"_lok.{0}" % key`, which is easier to read: _lok.key1, _lok.key2, etc.

A regex is used to validate the lock_prefix, restricting it to 2-10 chars `[A-Z0-9_-:.]`

A test for correct usage is provided.  Because the test system uses setupclass, I could not think of a good way to implement bad config args.

Fixes: #76
Change-Id: I22a6776168c78030e4472591a0c1e12a45b67cfb