### PR TITLE
Fix wrong argument name in doc

### DIFF
--- a/docs/build/changelog.rst
+++ b/docs/build/changelog.rst
@@ -297,7 +297,7 @@ Changelog
 
             :paramref:`.PyMemcacheBackend.hashclient_retry_timeout`
 
-            :paramref:`.PyMemcacheBackend.dead_timeout`
+            :paramref:`.PyMemcacheBackend.hashclient_dead_timeout`
 
 .. changelog::
     :version: 1.1.4

--- a/dogpile/cache/backends/memcached.py
+++ b/dogpile/cache/backends/memcached.py
@@ -560,8 +560,8 @@ class PyMemcacheBackend(GenericMemcachedBackend):
 
      .. versionadded:: 1.1.5
 
-    :param dead_timeout: Time in seconds before attempting to add a node
-     back in the pool in the HashClient's internal mechanisms.
+    :param hashclient_dead_timeout: Time in seconds before attempting to add
+     a node back in the pool in the HashClient's internal mechanisms.
 
      .. versionadded:: 1.1.5
 


### PR DESCRIPTION
Correct the argument name in docstring to reflect the actual key name used in the implementation.